### PR TITLE
Support Ruby 1.8 by not using "\unnnn" literals

### DIFF
--- a/docs/taglib/mp4.rb
+++ b/docs/taglib/mp4.rb
@@ -5,7 +5,7 @@ module TagLib::MP4
   # @example Finding an MP4 item by field name
   #   TagLib::MP4::File.open("file.m4a") do |mp4|
   #     item_list_map = mp4.tag.item_list_map
-  #     title = item_list_map["\u00a9nam"].to_string_list
+  #     title = item_list_map["\xC2\xA9nam"].to_string_list
   #     puts title.first
   #   end
   #
@@ -168,7 +168,7 @@ module TagLib::MP4
     alias :[] :fetch
 
     # @example Triggering an ObjectPreviouslyDeleted exception
-    #   remember_me = mp4.tag.item_list_map["\u00a9nam"]
+    #   remember_me = mp4.tag.item_list_map["\xC2\xA9nam"]
     #   mp4.tag.item_list_map.clear
     #   # => nil
     #   remember_me.to_string_list
@@ -197,8 +197,8 @@ module TagLib::MP4
 
     # Remove and destroy the value under `key`, if present.
     # @example Triggering an ObjectPreviouslyDeleted exception
-    #   remember_me = mp4.tag.item_list_map["\u00a9nam"]
-    #   mp4.tag.item_list_map.erase("\u00a9nam")
+    #   remember_me = mp4.tag.item_list_map["\xC2\xA9nam"]
+    #   mp4.tag.item_list_map.erase("\xC2\xA9nam")
     #   # => nil
     #   remember_me.to_string_list
     #   # ObjectPreviouslyDeleted: Expected argument 0 of type TagLib::MP4::Item const *, but got TagLib::MP4::Item #<TagLib::MP4::Item:0x007f919a...
@@ -213,8 +213,8 @@ module TagLib::MP4
 
     # Insert an item at `key`, destoying the existing item under `key`.
     # @example Triggering an ObjectPreviouslyDeleted exception
-    #   remember_me = mp4.tag.item_list_map["\u00a9nam"]
-    #   mp4.tag.item_list_map.insert("\u00a9nam", TagLib::MP4::Item.from_string_list(['New']))
+    #   remember_me = mp4.tag.item_list_map["\xC2\xA9nam"]
+    #   mp4.tag.item_list_map.insert("\xC2\xA9nam", TagLib::MP4::Item.from_string_list(['New']))
     #   remember_me.to_string_list
     #   # ObjectPreviouslyDeleted: Expected argument 0 of type TagLib::MP4::Item const *, but got TagLib::MP4::Item #<TagLib::MP4::Item:0x007f919a...
     #   # 	in SWIG method 'toStringList'

--- a/test/mp4_items_test.rb
+++ b/test/mp4_items_test.rb
@@ -2,14 +2,17 @@
 require File.join(File.dirname(__FILE__), 'helper')
 
 class MP4ItemsTest < Test::Unit::TestCase
+  ITUNES_LEADER = "\xC2\xA9"
+
   context "The mp4.m4a file's items" do
     setup do
       @file = TagLib::MP4::File.new("test/data/mp4.m4a")
       @tag = @file.tag
       @item_list_map = @file.tag.item_list_map
       @item_keys = [
-        "cover", "\u00A9nam", "\u00A9ART", "\u00A9alb", "\u00A9cmt", "\u00A9gen",
-        "\u00A9day", "trkn", "\u00A9too", "\u00A9cpy"
+        "cover", "#{ITUNES_LEADER}nam", "#{ITUNES_LEADER}ART", "#{ITUNES_LEADER}alb",
+        "#{ITUNES_LEADER}cmt", "#{ITUNES_LEADER}gen", "#{ITUNES_LEADER}day",
+        "trkn", "#{ITUNES_LEADER}too", "#{ITUNES_LEADER}cpy"
       ]
     end
 
@@ -28,19 +31,19 @@ class MP4ItemsTest < Test::Unit::TestCase
 
       should "have keys" do
         assert_equal true, @item_list_map.contains("trkn")
-        assert_equal true, @item_list_map.has_key?("\u00A9too")
-        assert_equal true, @item_list_map.include?("\u00A9cpy")
+        assert_equal true, @item_list_map.has_key?("#{ITUNES_LEADER}too")
+        assert_equal true, @item_list_map.include?("#{ITUNES_LEADER}cpy")
         assert_equal false, @item_list_map.include?("none such key")
       end
 
       should "look up keys" do
         assert_nil @item_list_map["none such key"]
-        assert_equal ["Title"], @item_list_map["\u00A9nam"].to_string_list
+        assert_equal ["Title"], @item_list_map["#{ITUNES_LEADER}nam"].to_string_list
       end
 
       should "be clearable" do
         assert_equal 10, @item_list_map.size
-        comment = @item_list_map["\u00A9cmt"]
+        comment = @item_list_map["#{ITUNES_LEADER}cmt"]
         @item_list_map.clear
         assert_equal true, @item_list_map.empty?
         begin
@@ -65,8 +68,8 @@ class MP4ItemsTest < Test::Unit::TestCase
 
     should "be removable" do
       assert_equal 10, @item_list_map.size
-      title = @item_list_map["\u00A9nam"]
-      @item_list_map.erase("\u00A9nam")
+      title = @item_list_map["#{ITUNES_LEADER}nam"]
+      @item_list_map.erase("#{ITUNES_LEADER}nam")
       assert_equal 9, @item_list_map.size
       begin
         title.to_string_list
@@ -79,15 +82,15 @@ class MP4ItemsTest < Test::Unit::TestCase
     context "inserting items" do
       should "insert a new item" do
         new_title = TagLib::MP4::Item.from_string_list(['new title'])
-        @item_list_map.insert("\u00A9nam", new_title)
+        @item_list_map.insert("#{ITUNES_LEADER}nam", new_title)
         new_title = nil
         GC.start
-        assert_equal ['new title'], @item_list_map["\u00A9nam"].to_string_list
+        assert_equal ['new title'], @item_list_map["#{ITUNES_LEADER}nam"].to_string_list
       end
 
       should "unlink items that get replaced" do
-        title = @item_list_map["\u00A9nam"]
-        @item_list_map.insert("\u00A9nam", TagLib::MP4::Item.from_int(1))
+        title = @item_list_map["#{ITUNES_LEADER}nam"]
+        @item_list_map.insert("#{ITUNES_LEADER}nam", TagLib::MP4::Item.from_int(1))
         begin
           title.to_string_list
           flunk("Should have raised ObjectPreviouslyDeleted.")


### PR DESCRIPTION
By using the wrong string keys, we were making some of the MP4 tests fail on Ruby 1.8.7. This commit addresses that issue.
