### PR TITLE
Associate filesystem encoding to filename strings

### DIFF
--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -24,9 +24,11 @@
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -87,12 +89,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {

--- a/ext/taglib_base/taglib_base_wrap.cxx
+++ b/ext/taglib_base/taglib_base_wrap.cxx
@@ -1868,9 +1868,11 @@ static VALUE mTagLib;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1931,12 +1933,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -2059,7 +2064,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2111,7 +2116,7 @@ SWIG_From_bool  (bool value)
 }
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_flac/taglib_flac_wrap.cxx
+++ b/ext/taglib_flac/taglib_flac_wrap.cxx
@@ -1876,9 +1876,11 @@ static VALUE mFLAC;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1939,12 +1941,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -1994,7 +1999,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
+++ b/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
@@ -1859,9 +1859,11 @@ static VALUE mID3v1;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1922,12 +1924,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -2016,7 +2021,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2072,7 +2077,7 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 }
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -1897,9 +1897,11 @@ static VALUE mID3v2;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1960,12 +1962,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -2124,7 +2129,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2176,7 +2181,7 @@ SWIG_From_bool  (bool value)
 }
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2314,7 +2319,7 @@ SWIG_From_float  (float value)
 #include <float.h>
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2DBL(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -1876,9 +1876,11 @@ static VALUE mMP4;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1939,12 +1941,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -2034,7 +2039,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2160,7 +2165,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
+++ b/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
@@ -1874,9 +1874,11 @@ static VALUE mMPEG;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1937,12 +1939,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -2065,7 +2070,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_ogg/taglib_ogg_wrap.cxx
+++ b/ext/taglib_ogg/taglib_ogg_wrap.cxx
@@ -1863,9 +1863,11 @@ static VALUE mOgg;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1926,12 +1928,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -1980,7 +1985,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2099,7 +2104,7 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 }
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
+++ b/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
@@ -1867,9 +1867,11 @@ static VALUE mVorbis;
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
 # define ASSOCIATE_UTF8_ENCODING(value) rb_enc_associate(value, rb_utf8_encoding());
+# define ASSOCIATE_FILESYSTEM_ENCODING(value) rb_enc_associate(value, rb_filesystem_encoding());
 # define CONVERT_TO_UTF8(value) rb_str_export_to_enc(value, rb_utf8_encoding())
 #else
 # define ASSOCIATE_UTF8_ENCODING(value) /* nothing */
+# define ASSOCIATE_FILESYSTEM_ENCODING(value)
 # define CONVERT_TO_UTF8(value) value
 #endif
 
@@ -1930,12 +1932,15 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
 }
 
 VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
+  VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  return rb_tainted_str_new2(s);
+  result = rb_tainted_str_new2(s);
 #else
-  return rb_tainted_str_new2(filename);
+  result = rb_tainted_str_new2(filename);
 #endif
+  ASSOCIATE_FILESYSTEM_ENCODING(result);
+  return result;
 }
 
 TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
@@ -1984,7 +1989,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/Cellar/swig/2.0.9/share/swig/2.0.9/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -1,0 +1,21 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+class TestFile < Test::Unit::TestCase
+  context "The sample.mp3 file" do
+    setup do
+      @mpeg_file = TagLib::MPEG::File.new("test/data/sample.mp3", false)
+    end
+
+    context "filename" do
+      should "be the right name" do
+        assert_equal 'test/data/sample.mp3', @mpeg_file.name
+      end
+
+      if HAVE_ENCODING
+        should "have the right encoding" do
+          assert_equal Encoding.find('filesystem'), @mpeg_file.name.encoding
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The [taglib documentation](http://taglib.github.io/api/classTagLib_1_1File.html#a861c7094cfac168df2f219aaabd66aac) promises the `name` attribute of a `File` has the filesystem encoding. This commit makes sure this is also true in taglib-ruby.
