### PR TITLE
Check for UnknownFrame when converting ID3v2 frames (#31)

### DIFF
--- a/docs/taglib/id3v2.rb
+++ b/docs/taglib/id3v2.rb
@@ -62,8 +62,13 @@ module TagLib::ID3v2
   #     file.save
   #   end
   class Tag < TagLib::Tag
-    # Get a list of frames. Note that the frames returned are subclasses
-    # of {TagLib::ID3v2::Frame}, depending on the frame ID.
+    # Get a list of frames.
+    #
+    # Note that the frames returned are subclasses of {TagLib::ID3v2::Frame},
+    # depending on the frame ID. But it's also possible that a
+    # {TagLib::ID3v2::UnknownFrame} is returned (e.g. when TagLib discards a
+    # deprecated frame). So to make sure your code can handle all the cases, it
+    # should include a check for the returned class of the frame.
     #
     # @overload frame_list()
     #   Returns all frames.
@@ -433,6 +438,11 @@ module TagLib::ID3v2
 
     # @return [String] owner
     attr_accessor :owner
+  end
+
+  # Unknown frame used by TagLib to represent a frame whose type is not
+  # known, not implemented or deprecated in later versions of ID3v2.
+  class UnknownFrame < Frame
   end
 
   # Unsynchronized lyrics frame (`USLT`).

--- a/ext/taglib_id3v2/taglib_id3v2.i
+++ b/ext/taglib_id3v2/taglib_id3v2.i
@@ -32,7 +32,9 @@ VALUE taglib_id3v2_frame_to_ruby_object(const TagLib::ID3v2::Frame *frame) {
   TagLib::ByteVector id = frame->frameID();
   void *f = SWIG_as_voidptr(frame);
   swig_type_info *ti;
-  if (id == "APIC")
+  if (dynamic_cast<const TagLib::ID3v2::UnknownFrame *>(frame))
+    ti = SWIGTYPE_p_TagLib__ID3v2__UnknownFrame;
+  else if (id == "APIC")
     ti = SWIGTYPE_p_TagLib__ID3v2__AttachedPictureFrame;
   else if (id == "COMM")
     ti = SWIGTYPE_p_TagLib__ID3v2__CommentsFrame;

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -2001,7 +2001,9 @@ VALUE taglib_id3v2_frame_to_ruby_object(const TagLib::ID3v2::Frame *frame) {
   TagLib::ByteVector id = frame->frameID();
   void *f = SWIG_as_voidptr(frame);
   swig_type_info *ti;
-  if (id == "APIC")
+  if (dynamic_cast<const TagLib::ID3v2::UnknownFrame *>(frame))
+    ti = SWIGTYPE_p_TagLib__ID3v2__UnknownFrame;
+  else if (id == "APIC")
     ti = SWIGTYPE_p_TagLib__ID3v2__AttachedPictureFrame;
   else if (id == "COMM")
     ti = SWIGTYPE_p_TagLib__ID3v2__CommentsFrame;

--- a/test/id3v2_unknown_frames_test.rb
+++ b/test/id3v2_unknown_frames_test.rb
@@ -1,0 +1,30 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+class TestID3v2UnknownFrames < Test::Unit::TestCase
+  context "UnknownFrame" do
+    setup do
+      read_properties = false
+      @file = TagLib::MPEG::File.new("test/data/sample.mp3", read_properties)
+      @tag = @file.id3v2_tag
+    end
+
+    should "should be returned with correct class" do
+      f = TagLib::ID3v2::UnknownFrame.new("TDAT")
+      assert_not_nil f
+      @tag.add_frame(f)
+      frames = @tag.frame_list("TDAT")
+      tdat = frames.first
+      assert_not_nil tdat
+      # By looking at ID alone, it would have returned a
+      # TextIdentificationFrame. So make sure the correct
+      # class is returned here, because it would result in
+      # segfaults when calling methods on it.
+      assert_equal TagLib::ID3v2::UnknownFrame, tdat.class
+    end
+
+    teardown do
+      @file.close
+      @file = nil
+    end
+  end
+end


### PR DESCRIPTION
Looking at the ID alone to determine the frame class is not enough. E.g.
for deprecated frames like TDAT, TagLib keeps the frame ID but returns
it as an UnknownFrame.

This change fixes the handling of such frames and adds a note to the
documentation of frame_list.
