### PR TITLE
Document some gotchas of mutable attributes

### DIFF
--- a/docs/taglib/base.rb
+++ b/docs/taglib/base.rb
@@ -23,6 +23,27 @@
 #
 # For ID3v2 frames, you can also set a default text encoding globally
 # using the {TagLib::ID3v2::FrameFactory}.
+#
+# ## Modifying attributes
+#
+# Mutable Ruby types (String, Array) returned by TagLib cannot be modified in-place.
+#
+# @example Modifying an attribute in-place does not work
+#   tag.title = 'Title'
+#   tag.title
+#   # => "Title"
+#   tag.title << ' of the song'
+#   # => "Title of the song"
+#   tag.title
+#   # => "Title"
+#
+# @example You need to replace the existing attribute value
+#   tag.title = 'Title'
+#   tag.title
+#   # => "Title"
+#   tag.title = 'Title of the song'
+#   tag.title
+#   # => "Title of the song"
 module TagLib
 
   # Major version of TagLib the extensions were compiled against


### PR DESCRIPTION
For convenience taglib-ruby returns Strings and Arrays in many places. A
user might expect that if they modify such an attribute in-place, the
modification is propagated to the underlying C++ object, which is not
the case. This commit adds documentation for this behaviour.

Inspired by #38.
