### PR TITLE
Allow CXX override during gem installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Then do:
 
     gem install taglib-ruby
 
+OS X C++ compiler override
+--------------------------
+
+Not all versions of TagLib get along with `clang++`, the default C++ compiler
+on OS X. To compile taglib-ruby's C++ extensions with a different compiler
+during installation, set the `TAGLIB_RUBY_CXX` environement variable.
+
+    TAGLIB_RUBY_CXX=g++-4.2 gem install taglib-ruby
+
 Usage
 -----
 

--- a/ext/extconf_common.rb
+++ b/ext/extconf_common.rb
@@ -31,3 +31,6 @@ DESC
 end
 
 $CFLAGS << " -DSWIG_TYPE_TABLE=taglib"
+
+# Allow users to override the Ruby runtime's preferred CXX
+RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['TAGLIB_RUBY_CXX'] if ENV['TAGLIB_RUBY_CXX']


### PR DESCRIPTION
TagLib 1.9.1 does not get along with clang++ on OS X 10.9, see
https://github.com/robinst/taglib-ruby/issues/44 . Overriding the C++
compiler used to compile taglib-ruby native extensions seems to solve
these problems.

Poking around in RbConfig feels like a hack but it is the best solution
I can come up with. I looked to Nokogiri for inspiration:

https://github.com/sparklemotion/nokogiri/blob/8f22560ab796e77a9a637c92cd5bf79261f1ad84/ext/nokogiri/extconf.rb#L299
