### PR TITLE
Try to find opt-dir for Heroku buildpack (#28)

### DIFF
--- a/ext/extconf_common.rb
+++ b/ext/extconf_common.rb
@@ -1,6 +1,17 @@
 # Default opt dirs to help mkmf find taglib
-configure_args = "--with-opt-dir=/usr/local:/opt/local:/sw "
+
+opt_dirs = ["/usr/local", "/opt/local", "/sw"]
+
+# Heroku vendor dir
+vendor = ENV.fetch('GEM_HOME', "")[/^[^ ]*\/vendor\//]
+if vendor
+  opt_dirs << (vendor + "taglib")
+end
+opt_dirs_joined = opt_dirs.join(":")
+
+configure_args = "--with-opt-dir=#{opt_dirs_joined} "
 ENV['CONFIGURE_ARGS'] = configure_args + ENV.fetch('CONFIGURE_ARGS', "")
+
 
 require 'mkmf'
 


### PR DESCRIPTION
On Heroku when building the extension, the taglib files are not
available via an absolute path. Instead, they are in a path like this:

  /tmp/build_0d73acfd-3d71-471a-ad6d-bbd02f5d55d8/vendor/taglib/lib/libtag.so

There are however multiple environment variables, one of them:

  GEM_HOME=/tmp/build_0d73acfd-3d71-471a-ad6d-bbd02f5d55d8/vendor/bundle/ruby/2.0.0

From this, we can extract the vendor path and append taglib to get the
opt dir we need.

It's not very clean, but it feels a bit better than using relative paths
using "..".

Also, it's only tested with the following buildpack, which downloads the
taglib binaries from somewhere (ugh):

https://github.com/mrrad/heroku-buildpack-taglib
