### PR TITLE
Fix compile error during gem installation on MRI 2.3 (#67)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.8.7
   - 2.0.0
   - 2.1.1
+  - 2.3.0
 addons:
   apt:
     packages:

--- a/ext/taglib_aiff/taglib_aiff_wrap.cxx
+++ b/ext/taglib_aiff/taglib_aiff_wrap.cxx
@@ -1936,7 +1936,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -81,7 +81,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_base/taglib_base_wrap.cxx
+++ b/ext/taglib_base/taglib_base_wrap.cxx
@@ -1939,7 +1939,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_flac/taglib_flac_wrap.cxx
+++ b/ext/taglib_flac/taglib_flac_wrap.cxx
@@ -1947,7 +1947,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
+++ b/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
@@ -1930,7 +1930,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -1968,7 +1968,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_mp4/taglib_mp4.i
+++ b/ext/taglib_mp4/taglib_mp4.i
@@ -44,7 +44,7 @@ TagLib::MP4::CoverArtList ruby_array_to_taglib_cover_art_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::MP4::CoverArt *c;
     SWIG_ConvertPtr(e, (void **) &c, SWIGTYPE_p_TagLib__MP4__CoverArt, 1);
     result.append(*c);

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -1947,7 +1947,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }
@@ -2027,7 +2027,7 @@ TagLib::MP4::CoverArtList ruby_array_to_taglib_cover_art_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::MP4::CoverArt *c;
     SWIG_ConvertPtr(e, (void **) &c, SWIGTYPE_p_TagLib__MP4__CoverArt, 1);
     result.append(*c);

--- a/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
+++ b/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
@@ -1947,7 +1947,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_ogg/taglib_ogg_wrap.cxx
+++ b/ext/taglib_ogg/taglib_ogg_wrap.cxx
@@ -1934,7 +1934,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
+++ b/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
@@ -1938,7 +1938,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }

--- a/ext/taglib_wav/taglib_wav_wrap.cxx
+++ b/ext/taglib_wav/taglib_wav_wrap.cxx
@@ -1936,7 +1936,7 @@ TagLib::StringList ruby_array_to_taglib_string_list(VALUE ary) {
     return result;
   }
   for (long i = 0; i < RARRAY_LEN(ary); i++) {
-    VALUE e = RARRAY_PTR(ary)[i];
+    VALUE e = rb_ary_entry(ary, i);
     TagLib::String s = ruby_string_to_taglib_string(e);
     result.append(s);
   }


### PR DESCRIPTION
Apparently, instead of RARRAY_PTR, rb_ary_entry should be used. On the
other hand, RARRAY_LEN is fine and doesn't seem to have an rb_ary_*
replacement. WHY JAPANESE PEOPLE WHY?

Also add 2.3.0 for travis, now that it should be green.