### PR TITLE
Update Rake tasks to easily run the CI against various versions of taglib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: ruby
-rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-addons:
-  apt:
-    packages:
-    - libtag1-dev
+env:
+  global:
+    - PLATFORM=x86_64-linux-gnu
+    - MAKEFLAGS="-j2"
+matrix:
+  include:
+    - rvm: 2.2.7
+      env: TAGLIB_VERSION=1.7.2 TAGLIB_DIR=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.7.2 LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.7.2/lib:$LD_LIBRARY_PATH
+    - rvm: 2.2.7
+      env: TAGLIB_VERSION=1.8 TAGLIB_DIR=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.8 LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.8/lib:$LD_LIBRARY_PATH
+    - rvm: 2.3.4
+      env: TAGLIB_VERSION=1.9.1 TAGLIB_DIR=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.9.1 LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.9.1/lib:$LD_LIBRARY_PATH
+    - rvm: 2.4.1
+      env: TAGLIB_VERSION=1.10 TAGLIB_DIR=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.10 LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.10/lib:$LD_LIBRARY_PATH
+    - rvm: 2.4.1
+      env: TAGLIB_VERSION=1.11.1 TAGLIB_DIR=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.11.1 LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/x86_64-linux-gnu/taglib-1.11.1/lib:$LD_LIBRARY_PATH
+before_script: bundle exec rake vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ addons:
   apt:
     packages:
     - libtag1-dev
-    - swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 2.0.0
-  - 2.1.1
-  - 2.3.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Build and install gem into system gems:
 
     rake install
 
+The `swig` and `compile` rake tasks can use the `TAGLIB_DIR` environment
+variable to build against non-standard taglib installations. It is assumed
+that taglib headers are located at `$TAGLIB_DIR/include` and taglib libraries
+at `$TAGLIB_DIR/lib`. To run taglib-ruby with non-standard taglib
+installations, use the `LD_LIBRARY_PATH` env. variable.
+
 ### Workflow
 
 * Check out the latest master to make sure the feature hasn't been

--- a/README.md
+++ b/README.md
@@ -95,11 +95,19 @@ Build and install gem into system gems:
 
     rake install
 
-The `swig` and `compile` rake tasks can use the `TAGLIB_DIR` environment
-variable to build against non-standard taglib installations. It is assumed
-that taglib headers are located at `$TAGLIB_DIR/include` and taglib libraries
-at `$TAGLIB_DIR/lib`. To run taglib-ruby with non-standard taglib
-installations, use the `LD_LIBRARY_PATH` env. variable.
+Build a specific version of Taglib:
+
+    PLATFORM=x86_64-linux TAGLIB_VERSION=1.9.1 rake vendor
+
+The above command will automatically download Taglig 1.9.1, build it and install it in `tmp/x86_64-linux/taglib-1.9.1`.
+
+The `swig` and `compile` tasks can then be executed against that specific version of Taglib by setting the `TAGLIB_DIR` environment variable to `$PWD/tmp/x86_64-linux/taglib-1.9.1` (it is assumed that taglib headers are located at `$TAGLIB_DIR/include` and taglib libraries at `$TAGLIB_DIR/lib`).
+
+The `test` task can then be run for that version of Taglib by adding `$PWD/tmp/x86_64-linux/taglib-1.9.1/lib` to the `LD_LIBRARY_PATH` environment variable.
+
+To do everything in one command:
+
+    PLATFORM=x86_64-linux TAGLIB_VERSION=1.7.2 TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-1.7.2 LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-1.7.2/lib rake vendor compile test
 
 ### Workflow
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,4 +25,14 @@ end
 
 $gemspec = Bundler::GemHelper.gemspec
 
-FileList['tasks/**/*.rake'].each { |task| import task }
+import 'tasks/docs_coverage.rake'
+import 'tasks/ext.rake'
+import 'tasks/gemspec_check.rake'
+
+# When importing swig.rake, the *_wrap.cxx files depend on being generated
+# by Swig. Since the ExtensionTasks depend on the *_wrap.cxx files,
+# compiling the extensions will trigger Swig, which is not desired as
+# those files have already been generated and there's no reason to make
+# Swig a variable of the CI. To prevent those dependencies, do not import
+# swig.rake when running in Travis.
+import 'tasks/swig.rake' unless ENV['TRAVIS'] == 'true'

--- a/ext/extconf_common.rb
+++ b/ext/extconf_common.rb
@@ -20,7 +20,14 @@ def error msg
   abort
 end
 
-dir_config('tag')
+if ENV.has_key?('TAGLIB_DIR') and !File.directory?(ENV['TAGLIB_DIR'])
+  error "When defined, the TAGLIB_DIR environment variable must point to a valid directory."
+end
+
+# If specified, use the TAGLIB_DIR environment variable as the prefix
+# for finding taglib headers and libs. See MakeMakefile#dir_config
+# for more details.
+dir_config('tag', (ENV['TAGLIB_DIR'] if ENV.has_key?('TAGLIB_DIR')))
 
 # When compiling statically, -lstdc++ would make the resulting .so to
 # have a dependency on an external libstdc++ instead of the static one.

--- a/ext/taglib_base/taglib_base.i
+++ b/ext/taglib_base/taglib_base.i
@@ -32,11 +32,12 @@ namespace TagLib {
 
 // Rename setters to Ruby convention (combining SWIG rename functions
 // does not seem to be possible, thus resort to some magic)
-%rename("%(command: ruby -e 'print(ARGV[0][3..-1].split(/(?=[A-Z])/).join(\"_\").downcase + \"=\")' )s",
+// setFoo -> foo=
+%rename("%(command: perl -e \"print lc(join('_', split(/(?=[A-Z])/, substr(@ARGV[0], 3)))), '='\" )s",
         regexmatch$name="^set[A-Z]") "";
 
 // isFoo -> foo?
-%rename("%(command: ruby -e 'print(ARGV[0][2..-1].split(/(?=[A-Z])/).join(\"_\").downcase + \"?\")' )s",
+%rename("%(command: perl -e \"print lc(join('_', split(/(?=[A-Z])/, substr(@ARGV[0], 2)))), '?'\" )s",
         regexmatch$name="^is[A-Z]") "";
 
 // ByteVector

--- a/tasks/swig.rake
+++ b/tasks/swig.rake
@@ -1,11 +1,30 @@
 # Tasks for generating SWIG wrappers in ext
 
+# Execute SWIG for the specified extension.
+# Arguments:
+# mod:: The name of the SWIG wrapper to process.
+#
+# If the TAGLIB_DIR environment variable points to a directory,
+# $TAGLIB_DIR/include will be searched first for taglib headers.
 def run_swig(mod)
   swig = `which swig`.chomp
   if swig.empty?
     swig = `which swig2.0`.chomp
   end
-  sh "cd ext/#{mod} && #{swig} -c++ -ruby -autorename -initname #{mod} -I/usr/local/include -I/usr/include #{mod}.i"
+
+  # Standard search location for headers
+  include_args = %w{-I/usr/local/include -I/usr/include}
+
+  if ENV.has_key?('TAGLIB_DIR')
+    unless File.directory?(ENV['TAGLIB_DIR'])
+      abort "When defined, the TAGLIB_DIR environment variable must point to a valid directory."
+    end
+
+    # Push it in front to get it searched first.
+    include_args.unshift('-I' + ENV['TAGLIB_DIR'] + '/include')
+  end
+
+  sh "cd ext/#{mod} && #{swig} -c++ -ruby -autorename -initname #{mod} #{include_args.join(' ')} #{mod}.i"
 end
 
 task :swig =>

--- a/test/flac_file_test.rb
+++ b/test/flac_file_test.rb
@@ -37,7 +37,14 @@ class FlacFileTest < Test::Unit::TestCase
 
       should "contain basic information" do
         assert_equal 1, @properties.length
-        assert_equal 212, @properties.bitrate
+
+        # taglib/taglib#557 changed the way bitrate is calculated.
+        if TagLib::TAGLIB_MAJOR_VERSION > 1 || (TagLib::TAGLIB_MAJOR_VERSION == 1 && TagLib::TAGLIB_MINOR_VERSION >= 10)
+          assert_equal 209, @properties.bitrate
+        else
+          assert_equal 212, @properties.bitrate
+        end
+
         assert_equal 44100, @properties.sample_rate
         assert_equal 1, @properties.channels
       end

--- a/test/id3v2_tag_test.rb
+++ b/test/id3v2_tag_test.rb
@@ -44,11 +44,20 @@ class TestID3v2Tag < Test::Unit::TestCase
     end
 
     should "have nil for string attributes" do
-      assert_nil @tag.title
-      assert_nil @tag.artist
-      assert_nil @tag.album
-      assert_nil @tag.comment
-      assert_nil @tag.genre
+      # taglib/taglib/8c6fe45: return an empty string instead of NULL
+      if TagLib::TAGLIB_MAJOR_VERSION > 1 || (TagLib::TAGLIB_MAJOR_VERSION == 1 && TagLib::TAGLIB_MINOR_VERSION >= 11)
+        assert_equal "", @tag.title
+        assert_equal "", @tag.artist
+        assert_equal "", @tag.album
+        assert_equal "", @tag.comment
+        assert_equal "", @tag.genre
+      else
+        assert_nil @tag.title
+        assert_nil @tag.artist
+        assert_nil @tag.album
+        assert_nil @tag.comment
+        assert_nil @tag.genre
+      end
     end
 
     should "have 0 for numeric attributes" do

--- a/test/mp4_file_test.rb
+++ b/test/mp4_file_test.rb
@@ -29,7 +29,14 @@ class MP4FileTest < Test::Unit::TestCase
 
       should "contain basic information" do
         assert_equal 1, @properties.length
-        assert_equal 54, @properties.bitrate
+
+        # taglib/taglib#558 changed the way bitrate is calculated.
+        if TagLib::TAGLIB_MAJOR_VERSION > 1 || (TagLib::TAGLIB_MAJOR_VERSION == 1 && TagLib::TAGLIB_MINOR_VERSION >= 10)
+          assert_equal 55, @properties.bitrate
+        else
+          assert_equal 54, @properties.bitrate
+        end
+
         assert_equal 44100, @properties.sample_rate
         # The test file is mono, this appears to be a TagLib bug
         assert_equal 2, @properties.channels

--- a/test/vorbis_file_test.rb
+++ b/test/vorbis_file_test.rb
@@ -23,7 +23,14 @@ class TestVorbisFile < Test::Unit::TestCase
 
       should "contain basic information" do
         assert_equal 0, @properties.length # file is short
-        assert_equal 64, @properties.bitrate
+
+        # taglib/taglib#563 changed the way bitrate is calculated.
+        if TagLib::TAGLIB_MAJOR_VERSION > 1 || (TagLib::TAGLIB_MAJOR_VERSION == 1 && TagLib::TAGLIB_MINOR_VERSION >= 10)
+          assert_equal 222, @properties.bitrate
+        else
+          assert_equal 64, @properties.bitrate
+        end
+
         assert_equal 44100, @properties.sample_rate
         assert_equal 2, @properties.channels
       end


### PR DESCRIPTION
A "vendor" task has been added to automatically get Rake to build a specific version of Taglib (version specified by an environment variable).
The Travis configuration has been updated to automatically get the CI to use versions 1.7.2, 1.8, 1.9.1, 1.10 & 1.11.1 of Taglib.