### PR TITLE
Pushed bundler version to 2.1 and can we push to Ruby Gems?

### DIFF
--- a/lib/taglib/version.rb
+++ b/lib/taglib/version.rb
@@ -2,7 +2,7 @@ module TagLib
   module Version
     MAJOR = 0
     MINOR = 7
-    PATCH = 1
+    PATCH = 2
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')

--- a/taglib-ruby.gemspec
+++ b/taglib-ruby.gemspec
@@ -23,7 +23,7 @@ DESC
   s.require_paths = ["lib"]
   s.requirements = ["taglib (libtag1-dev in Debian/Ubuntu, taglib-devel in Fedora/RHEL)"]
 
-  s.add_development_dependency 'bundler', '~> 1.2'
+  s.add_development_dependency 'bundler', '~> 2.1'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'shoulda-context', '~> 1.0'
   s.add_development_dependency 'yard', '~> 0.9.12'


### PR DESCRIPTION
Hello,

I was able to build this locally by changing the Bundler requirement to 2.1. Along with this I am wondering if we can push this to Ruby Gems as a script I have requires the `length_in_milliseconds` method and the current version on Ruby Gems only supports `length`. This will cause breakage in existing apps so I'm not sure if the version should actually be pushed up to 8 instead of 7.1. 

I am very new to Ruby so if anything seems weird about this let me know but it would be awesome to get the latest TagLib changes onto Ruby Gems!