### PR TITLE
Stop using tainted Ruby strings

### DIFF
--- a/ext/taglib_aiff/taglib_aiff_wrap.cxx
+++ b/ext/taglib_aiff/taglib_aiff_wrap.cxx
@@ -1891,7 +1891,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1907,7 +1907,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1947,9 +1947,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -36,7 +36,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -52,7 +52,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -92,9 +92,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_base/taglib_base_wrap.cxx
+++ b/ext/taglib_base/taglib_base_wrap.cxx
@@ -1894,7 +1894,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1910,7 +1910,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1950,9 +1950,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_flac/taglib_flac_wrap.cxx
+++ b/ext/taglib_flac/taglib_flac_wrap.cxx
@@ -1900,7 +1900,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1916,7 +1916,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1956,9 +1956,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
+++ b/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
@@ -1885,7 +1885,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1901,7 +1901,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1941,9 +1941,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
+++ b/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
@@ -1887,7 +1887,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1903,7 +1903,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1943,9 +1943,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -1923,7 +1923,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1939,7 +1939,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1979,9 +1979,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -1903,7 +1903,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1919,7 +1919,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1959,9 +1959,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
+++ b/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
@@ -1900,7 +1900,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1916,7 +1916,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1956,9 +1956,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_ogg/taglib_ogg_wrap.cxx
+++ b/ext/taglib_ogg/taglib_ogg_wrap.cxx
@@ -1894,7 +1894,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1910,7 +1910,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1950,9 +1950,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
+++ b/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
@@ -1894,7 +1894,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1910,7 +1910,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1950,9 +1950,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/ext/taglib_wav/taglib_wav_wrap.cxx
+++ b/ext/taglib_wav/taglib_wav_wrap.cxx
@@ -1892,7 +1892,7 @@ VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
   if (byteVector.isNull()) {
     return Qnil;
   } else {
-    return rb_tainted_str_new(byteVector.data(), byteVector.size());
+    return rb_str_new(byteVector.data(), byteVector.size());
   }
 }
 
@@ -1908,7 +1908,7 @@ VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
   if (string.isNull()) {
     return Qnil;
   } else {
-    VALUE result = rb_tainted_str_new2(string.toCString(true));
+    VALUE result = rb_str_new2(string.toCString(true));
     ASSOCIATE_UTF8_ENCODING(result);
     return result;
   }
@@ -1948,9 +1948,9 @@ VALUE taglib_filename_to_ruby_string(TagLib::FileName filename) {
   VALUE result;
 #ifdef _WIN32
   const char *s = (const char *) filename;
-  result = rb_tainted_str_new2(s);
+  result = rb_str_new2(s);
 #else
-  result = rb_tainted_str_new2(filename);
+  result = rb_str_new2(filename);
 #endif
   ASSOCIATE_FILESYSTEM_ENCODING(result);
   return result;

--- a/taglib-ruby.gemspec
+++ b/taglib-ruby.gemspec
@@ -23,7 +23,7 @@ DESC
   s.require_paths = ["lib"]
   s.requirements = ["taglib (libtag1-dev in Debian/Ubuntu, taglib-devel in Fedora/RHEL)"]
 
-  s.add_development_dependency 'bundler', '~> 1.2'
+  s.add_development_dependency 'bundler', '>= 1.2', '< 3'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'shoulda-context', '~> 1.0'
   s.add_development_dependency 'yard', '~> 0.9.12'


### PR DESCRIPTION
Closes https://github.com/robinst/taglib-ruby/issues/86.

Ruby is moving towards deprecating the tainted string mechanism:
see https://bugs.ruby-lang.org/issues/16131. In Ruby 2.7 with verbose
mode, you will get a deprecation warning every time your code
instantiates a tainted string.

This change updates taglib-ruby to stop using tainted strings.