### PR TITLE
Upgrade yard and kramdown deps

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -5,5 +5,5 @@
 docs/**/*.rb
 -
 README.md
-CHANGES.md
+CHANGELOG.md
 LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To do everything in one command:
 
 ### Workflow
 
-* Check out the latest master to make sure the feature hasn't been
+* Check out the latest main branch to make sure the feature hasn't been
   implemented or the bug hasn't been fixed yet
 * Check out the issue tracker to make sure someone already hasn't
   requested it and/or contributed it

--- a/taglib-ruby.gemspec
+++ b/taglib-ruby.gemspec
@@ -26,8 +26,8 @@ DESC
   s.add_development_dependency 'bundler', '>= 1.2', '< 3'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'shoulda-context', '~> 1.0'
-  s.add_development_dependency 'yard', '~> 0.9.12'
-  s.add_development_dependency 'kramdown', '~> 1.0'
+  s.add_development_dependency 'yard', '~> 0.9.26'
+  s.add_development_dependency 'kramdown', '~> 2.3.0'
   s.add_development_dependency 'test-unit', '~> 3.1'
 
   s.extensions = [


### PR DESCRIPTION
Should fix the "potential security vulnerability" warning. Note that the dependency is only used in development.