### PR TITLE
Added CI steps to install and run SWIG to generate wrappers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       PLATFORM: x86_64-linux
       TAGLIB_VERSION: 1.11.1
-      SKIP_SWIG: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
@@ -33,7 +32,9 @@ jobs:
           make
           sudo make install
       - name: Generate SWIG wrappers
-        run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake swig
+        run: |
+          touch ext/*/*.i
+          TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake swig
       - name: Compile
         run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake compile
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,31 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'docs/**'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        ruby: [2.4, 2.7]
+        os: [ubuntu-20.04]
+        ruby: [2.5, 2.6, 2.7]
+
+    runs-on: ${{ matrix.os }}
 
     env:
+      MAKEFLAGS: -j2
       PLATFORM: x86_64-linux
       TAGLIB_VERSION: 1.11.1
-      SWIG_INSTALL_DIR: .swig-v3.0.7
+      SWIG_DIR: .swig-v3.0.7
 
     steps:
       - uses: actions/checkout@v2
@@ -22,40 +34,46 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - name: Bundle Install Gem Depedencies
-        run: |
-          gem install bundler
-          bundle install
+      - name: Cache SWIG v3.0.7
+        id: cache-swig
+        uses: actions/cache@v2
+        with:
+          path: ~/${{ env.SWIG_DIR }}
+          key: swig-${{ matrix.os }}-v3.0.7
 
-      - name: Install TagLib
-        run: bundle exec rake vendor
-
-      # Download and install SWIG v3.0.7 for Ruby.
       - name: Install SWIG v3.0.7
         run: |
           sudo apt install yodl
           git clone --depth 1 --branch v3.0.7 https://github.com/swig/swig.git
           cd swig
           ./autogen.sh
-          ./configure --prefix=$HOME/$SWIG_INSTALL_DIR --with-ruby=$(which ruby) --without-alllang
+          ./configure --prefix=$HOME/$SWIG_DIR --with-ruby=$(which ruby) --without-alllang
           make && make install
 
-      # The precedence of SWIG v3.0.7 must be higher than the default ones i.e.:
-      # - Ubuntu 18.04 (SWIG v3.0.12) (https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md)
-      # - Ubuntu 20.04 (SWIG v4.0.1)  (https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)
-      # Because `which swig` is being used in the `swig.rake` file. The one with the higher precendence will be found first in PATH.
-      # As of now, the `ubuntu-latest` is Ubuntu 18.04 which will be switched to Ubuntu 20.04 in the future.
-      # So, it makes sense to cater to these changes.
-      # In addition, `SWIG_LIB` environment variable needs to be set accordingly.
-      - name: Generate SWIG wrappers
+      - name: Bundle Install
         run: |
-          export PATH=$HOME/$SWIG_INSTALL_DIR/bin:$PATH
-          export SWIG_LIB=$HOME/$SWIG_INSTALL_DIR/share/swig/3.0.7
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Cache TagLib (C++)
+        id: cache-taglib
+        uses: actions/cache@v2
+        with:
+          path: tmp/${{ env.PLATFORM }}/taglib-${{ env.TAGLIB_VERSION }}
+          key: taglib-${{ matrix.os }}-v${{ env.TAGLIB_VERSION }}
+
+      - name: Install TagLib (C++)
+        run: bundle exec rake vendor
+
+      - name: Generate SWIG Wrappers
+        run: |
           touch ext/*/*.i
-          TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake swig
+          export PATH=$HOME/$SWIG_DIR/bin:$PATH
+          TAGLIB_DIR=$PWD/tmp/$PLATFORM/taglib-$TAGLIB_VERSION bundle exec rake swig
 
-      - name: Compile taglib-ruby
-        run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake compile
+      - name: Compile (taglib-ruby)
+        run: TAGLIB_DIR=$PWD/tmp/$PLATFORM/taglib-$TAGLIB_VERSION bundle exec rake compile
 
-      - name: Run tests
-        run: bundle exec rake test
+      - name: Run Tests (taglib-ruby)
+        run: LD_LIBRARY_PATH=$PWD/tmp/$PLATFORM/taglib-$TAGLIB_VERSION/lib bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,37 +5,57 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         ruby: [2.4, 2.7]
+
     env:
       PLATFORM: x86_64-linux
       TAGLIB_VERSION: 1.11.1
+      SWIG_INSTALL_DIR: .swig-v3.0.7
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Bundle install
+
+      - name: Bundle Install Gem Depedencies
         run: |
           gem install bundler
           bundle install
-      - name: Install taglib
+
+      - name: Install TagLib
         run: bundle exec rake vendor
+
+      # Download and install SWIG v3.0.7 for Ruby.
       - name: Install SWIG v3.0.7
         run: |
           sudo apt install yodl
           git clone --depth 1 --branch v3.0.7 https://github.com/swig/swig.git
           cd swig
           ./autogen.sh
-          ./configure
-          make
-          sudo make install
+          ./configure --prefix=$HOME/$SWIG_INSTALL_DIR --with-ruby=$(which ruby) --without-alllang
+          make && make install
+
+      # The precedence of SWIG v3.0.7 must be higher than the default ones i.e.:
+      # - Ubuntu 18.04 (SWIG v3.0.12) (https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md)
+      # - Ubuntu 20.04 (SWIG v4.0.1)  (https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)
+      # Because `which swig` is being used in the `swig.rake` file. The one with the higher precendence will be found first in PATH.
+      # As of now, the `ubuntu-latest` is Ubuntu 18.04 which will be switched to Ubuntu 20.04 in the future.
+      # So, it makes sense to cater to these changes.
+      # In addition, `SWIG_LIB` environment variable needs to be set accordingly.
       - name: Generate SWIG wrappers
         run: |
+          export PATH=$HOME/$SWIG_INSTALL_DIR/bin:$PATH
+          export SWIG_LIB=$HOME/$SWIG_INSTALL_DIR/share/swig/3.0.7
           touch ext/*/*.i
           TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake swig
-      - name: Compile
+
+      - name: Compile taglib-ruby
         run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake compile
-      - name: Test
+
+      - name: Run tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
 
       - name: Bundle Install Gem Depedencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
       - name: Bundle Install Gem Depedencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
           bundle install
       - name: Install taglib
         run: bundle exec rake vendor
+      - name: Install SWIG v3.0.7
+        run: |
+          sudo apt install yodl
+          git clone --depth 1 --branch v3.0.7 https://github.com/swig/swig.git
+          cd swig
+          ./autogen.sh
+          ./configure
+          make
+          sudo make install
+      - name: Generate SWIG wrappers
+        run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake swig
       - name: Compile
         run: TAGLIB_DIR=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION LD_LIBRARY_PATH=$PWD/tmp/x86_64-linux/taglib-$TAGLIB_VERSION/lib bundle exec rake compile
       - name: Test


### PR DESCRIPTION
Added CI steps to install and run SWIG to generate wrappers.

Tested after commenting `SKIP_SWIG: true` and by adding`touch ext/*/*.i`.
Kindly adjust the environment variable accordingly.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>