### PR TITLE
Bump test-unit dependency for Ruby 3.2 (or earlier) compat

### DIFF
--- a/taglib-ruby.gemspec
+++ b/taglib-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'kramdown', '~> 2.3.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'shoulda-context', '~> 1.0'
-  s.add_development_dependency 'test-unit', '~> 3.1'
+  s.add_development_dependency 'test-unit', '~> 3.5'
   s.add_development_dependency 'yard', '~> 0.9.26'
 
   s.extensions = [


### PR DESCRIPTION
Was getting this error:

```
~/Projects/taglib-ruby/taglib-ruby/vendor/bundle/ruby/3.2.0+1/gems/power_assert-1.2.0/lib/power_assert/enable_tracepoint_events.rb:16:in `<module:PowerAssert>': uninitialized constant PowerAssert::Fixnum (NameError)

          Fixnum, Float, String, Array, Hash, Bignum, Symbol, Time, Regexp, NilClass, TrueClass, FalseClass
          ^^^^^^
```