### PR TITLE
Bump shoulda-context

### DIFF
--- a/taglib-ruby.gemspec
+++ b/taglib-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '>= 1.2', '< 3'
   s.add_development_dependency 'kramdown', '~> 2.3.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'shoulda-context', '~> 1.0'
+  s.add_development_dependency 'shoulda-context', '~> 2.0'
   s.add_development_dependency 'test-unit', '~> 3.5'
   s.add_development_dependency 'yard', '~> 0.9.26'
 


### PR DESCRIPTION
Should fix this warning:

> .../vendor/bundle/ruby/3.2.0+1/gems/shoulda-context-1.2.2/lib/shoulda/context/context.rb:400: warning: assigned but unused variable - context