### PR TITLE
Fix tests on taglib 1.12

### DIFF
--- a/test/id3v2_frames_test.rb
+++ b/test/id3v2_frames_test.rb
@@ -166,8 +166,8 @@ class TestID3v2Frames < Test::Unit::TestCase
       end
 
       should 'have to_s' do
-        expected = '[MusicBrainz Album Id] MusicBrainz Album Id 992dc19a-5631-40f5-b252-fbfedbc328a9'
-        assert_equal expected, @txxx_frame.to_string
+        expected = /\[MusicBrainz Album Id\].* 992dc19a-5631-40f5-b252-fbfedbc328a9/
+        assert_match expected, @txxx_frame.to_string
       end
 
       should 'have field_list' do

--- a/test/vorbis_file_test.rb
+++ b/test/vorbis_file_test.rb
@@ -25,7 +25,7 @@ class TestVorbisFile < Test::Unit::TestCase
 
       should 'contain basic information' do
         assert_equal 0, @properties.length_in_seconds # file is short
-        assert_equal 371, @properties.bitrate
+        assert_includes [371, 76], @properties.bitrate
         assert_equal 44100, @properties.sample_rate
         assert_equal 2, @properties.channels
       end


### PR DESCRIPTION
1.12 includes some fixes which affect our tests, see https://github.com/taglib/taglib/releases/tag/v1.12

They should still work on 1.11.1 too.