### PR TITLE
Fix UserTextIdentificationFrame constructor

### DIFF
--- a/ext/taglib_base/taglib_base.i
+++ b/ext/taglib_base/taglib_base.i
@@ -96,6 +96,9 @@ namespace TagLib {
   tmp = ruby_array_to_taglib_string_list($input);
   $1 = &tmp;
 }
+%typemap(typecheck, precedence=SWIG_TYPECHECK_LIST) TagLib::StringList {
+  $1 = TYPE($input) == T_ARRAY ? 1 : 0;
+}
 %apply TagLib::StringList { TagLib::StringList &, const TagLib::StringList & };
 
 %typemap(out) TagLib::FileName {

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -1872,15 +1872,14 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__ID3v2__UserTextIdentificationFrame swig_types[25]
 #define SWIGTYPE_p_TagLib__ID3v2__UserUrlLinkFrame swig_types[26]
 #define SWIGTYPE_p_TagLib__ListT_TagLib__ID3v2__Frame_p_t swig_types[27]
-#define SWIGTYPE_p_TagLib__StringList swig_types[28]
-#define SWIGTYPE_p_TagLib__Tag swig_types[29]
-#define SWIGTYPE_p_char swig_types[30]
-#define SWIGTYPE_p_unsigned_char swig_types[31]
-#define SWIGTYPE_p_unsigned_int swig_types[32]
-#define SWIGTYPE_p_unsigned_long swig_types[33]
-#define SWIGTYPE_p_wchar_t swig_types[34]
-static swig_type_info *swig_types[36];
-static swig_module_info swig_module = {swig_types, 35, 0, 0, 0, 0};
+#define SWIGTYPE_p_TagLib__Tag swig_types[28]
+#define SWIGTYPE_p_char swig_types[29]
+#define SWIGTYPE_p_unsigned_char swig_types[30]
+#define SWIGTYPE_p_unsigned_int swig_types[31]
+#define SWIGTYPE_p_unsigned_long swig_types[32]
+#define SWIGTYPE_p_wchar_t swig_types[33]
+static swig_type_info *swig_types[35];
+static swig_module_info swig_module = {swig_types, 34, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -9250,9 +9249,9 @@ SWIGINTERN VALUE _wrap_new_UserTextIdentificationFrame(int nargs, VALUE *args, V
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__StringList, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        _v = TYPE(argv[1]) == T_ARRAY ? 1 : 0;
+      }
       if (_v) {
         return _wrap_new_UserTextIdentificationFrame__SWIG_4(nargs, args, self);
       }
@@ -9263,9 +9262,9 @@ SWIGINTERN VALUE _wrap_new_UserTextIdentificationFrame(int nargs, VALUE *args, V
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__StringList, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        _v = TYPE(argv[1]) == T_ARRAY ? 1 : 0;
+      }
       if (_v) {
         {
           int res = SWIG_AsVal_int(argv[2], NULL);
@@ -10707,7 +10706,6 @@ static swig_type_info _swigt__p_TagLib__ID3v2__UrlLinkFrame = {"_p_TagLib__ID3v2
 static swig_type_info _swigt__p_TagLib__ID3v2__UserTextIdentificationFrame = {"_p_TagLib__ID3v2__UserTextIdentificationFrame", "TagLib::ID3v2::UserTextIdentificationFrame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__UserUrlLinkFrame = {"_p_TagLib__ID3v2__UserUrlLinkFrame", "TagLib::ID3v2::UserUrlLinkFrame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t = {"_p_TagLib__ListT_TagLib__ID3v2__Frame_p_t", "TagLib::ID3v2::FrameList *|TagLib::List< TagLib::ID3v2::Frame * > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__StringList = {"_p_TagLib__StringList", "TagLib::StringList *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
@@ -10744,7 +10742,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__ID3v2__UserTextIdentificationFrame,
   &_swigt__p_TagLib__ID3v2__UserUrlLinkFrame,
   &_swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t,
-  &_swigt__p_TagLib__StringList,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
   &_swigt__p_unsigned_char,
@@ -10781,7 +10778,6 @@ static swig_cast_info _swigc__p_TagLib__ID3v2__UrlLinkFrame[] = {  {&_swigt__p_T
 static swig_cast_info _swigc__p_TagLib__ID3v2__UserTextIdentificationFrame[] = {  {&_swigt__p_TagLib__ID3v2__UserTextIdentificationFrame, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__UserUrlLinkFrame[] = {  {&_swigt__p_TagLib__ID3v2__UserUrlLinkFrame, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t[] = {  {&_swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_TagLib__StringList[] = {  {&_swigt__p_TagLib__StringList, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__ID3v2__Tag, _p_TagLib__ID3v2__TagTo_p_TagLib__Tag, 0, 0},  {&_swigt__p_TagLib__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
@@ -10818,7 +10814,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__ID3v2__UserTextIdentificationFrame,
   _swigc__p_TagLib__ID3v2__UserUrlLinkFrame,
   _swigc__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t,
-  _swigc__p_TagLib__StringList,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
   _swigc__p_unsigned_char,

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -1858,15 +1858,14 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__MP4__Properties swig_types[8]
 #define SWIGTYPE_p_TagLib__MP4__Tag swig_types[9]
 #define SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t swig_types[10]
-#define SWIGTYPE_p_TagLib__StringList swig_types[11]
-#define SWIGTYPE_p_TagLib__Tag swig_types[12]
-#define SWIGTYPE_p_char swig_types[13]
-#define SWIGTYPE_p_unsigned_char swig_types[14]
-#define SWIGTYPE_p_unsigned_int swig_types[15]
-#define SWIGTYPE_p_unsigned_long swig_types[16]
-#define SWIGTYPE_p_wchar_t swig_types[17]
-static swig_type_info *swig_types[19];
-static swig_module_info swig_module = {swig_types, 18, 0, 0, 0, 0};
+#define SWIGTYPE_p_TagLib__Tag swig_types[11]
+#define SWIGTYPE_p_char swig_types[12]
+#define SWIGTYPE_p_unsigned_char swig_types[13]
+#define SWIGTYPE_p_unsigned_int swig_types[14]
+#define SWIGTYPE_p_unsigned_long swig_types[15]
+#define SWIGTYPE_p_wchar_t swig_types[16]
+static swig_type_info *swig_types[18];
+static swig_module_info swig_module = {swig_types, 17, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4001,15 +4000,6 @@ SWIGINTERN VALUE _wrap_new_Item(int nargs, VALUE *args, VALUE self) {
   if (argc == 1) {
     int _v;
     void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__StringList, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Item__SWIG_8(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v;
-    void *vptr = 0;
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ByteVectorList, SWIG_POINTER_NO_NULL);
     _v = SWIG_CheckState(res);
     if (_v) {
@@ -4063,6 +4053,15 @@ SWIGINTERN VALUE _wrap_new_Item(int nargs, VALUE *args, VALUE self) {
     }
     if (_v) {
       return _wrap_new_Item__SWIG_5(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v;
+    {
+      _v = TYPE(argv[0]) == T_ARRAY ? 1 : 0;
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_8(nargs, args, self);
     }
   }
   if (argc == 1) {
@@ -5223,7 +5222,6 @@ static swig_type_info _swigt__p_TagLib__MP4__Item = {"_p_TagLib__MP4__Item", "Ta
 static swig_type_info _swigt__p_TagLib__MP4__Properties = {"_p_TagLib__MP4__Properties", "TagLib::MP4::Properties *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MP4__Tag = {"_p_TagLib__MP4__Tag", "TagLib::MP4::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t = {"_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *|TagLib::MP4::ItemListMap *|TagLib::MP4::ItemMap *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__StringList = {"_p_TagLib__StringList", "TagLib::StringList *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
@@ -5243,7 +5241,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__MP4__Properties,
   &_swigt__p_TagLib__MP4__Tag,
   &_swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,
-  &_swigt__p_TagLib__StringList,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
   &_swigt__p_unsigned_char,
@@ -5263,7 +5260,6 @@ static swig_cast_info _swigc__p_TagLib__MP4__Item[] = {  {&_swigt__p_TagLib__MP4
 static swig_cast_info _swigc__p_TagLib__MP4__Properties[] = {  {&_swigt__p_TagLib__MP4__Properties, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MP4__Tag[] = {  {&_swigt__p_TagLib__MP4__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t[] = {  {&_swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_TagLib__StringList[] = {  {&_swigt__p_TagLib__StringList, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},  {&_swigt__p_TagLib__MP4__Tag, _p_TagLib__MP4__TagTo_p_TagLib__Tag, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
@@ -5283,7 +5279,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__MP4__Properties,
   _swigc__p_TagLib__MP4__Tag,
   _swigc__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,
-  _swigc__p_TagLib__StringList,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
   _swigc__p_unsigned_char,

--- a/test/id3v2_frames_test.rb
+++ b/test/id3v2_frames_test.rb
@@ -173,6 +173,11 @@ class TestID3v2Frames < Test::Unit::TestCase
       should 'have field_list' do
         assert_equal ['MusicBrainz Album Id', '992dc19a-5631-40f5-b252-fbfedbc328a9'], @txxx_frame.field_list
       end
+
+      should 'constructor with all arguments should work' do
+        frame = TagLib::ID3v2::UserTextIdentificationFrame.new("UserFrame", ["Some User Text"], TagLib::String::UTF8)
+        assert_equal ["UserFrame", "Some User Text"], frame.field_list
+      end
     end
 
     teardown do


### PR DESCRIPTION
Calling the constructor with `TagLib::StringList` didn't work before because of a missing typecheck typemap. Without that, swig doesn't know that a Ruby array works for a `TagLib::StringList` argument.

See https://www.swig.org/Doc4.0/SWIGDocumentation.html#Typemaps_overloading

Fixes #107.