### PR TITLE
Use C++17 for TagLib 2.0

### DIFF
--- a/ext/extconf_common.rb
+++ b/ext/extconf_common.rb
@@ -46,5 +46,10 @@ end
 
 $CFLAGS << ' -DSWIG_TYPE_TABLE=taglib'
 
+# TagLib 2.0 requires C++17. Some compilers default to an older standard
+# so we add this '-std=' option to make sure the compiler accepts C++17
+# code.
+$CXXFLAGS << ' -std=c++17'
+
 # Allow users to override the Ruby runtime's preferred CXX
 RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['TAGLIB_RUBY_CXX'] if ENV['TAGLIB_RUBY_CXX']


### PR DESCRIPTION
On macOS 13.6, the default C++ version is `gnu++98`. TagLib 2.0 needs C++17. This commit adds a `-std=` C++ flag to make sure the compiler runs in C++17 mode.