### PR TITLE
Update Ruby CI matrix to 3.1, 3.2, 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        ruby: [2.7, 3.2]
+        ruby: [3.1, 3.2, 3.3]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
These are the stable Ruby releases at the time of this commit.