### PR TITLE
Mark *_wrap.cxx as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*_wrap.cxx linguist-generated=true


### PR DESCRIPTION
See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

This will cause GitHub to collapse the changes in diffs by default. The changes can still be viewed by expanding the diff if desired. Should make it a bit easier to review PRs with changes to wrappers.