### PR TITLE
Fix build on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Bundle Install
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
Build [failed with](https://github.com/robinst/taglib-ruby/actions/runs/8579696840/job/23514956140?pr=134):

```
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```