### PR TITLE
Use vendored taglib for swig

### DIFF
--- a/ext/taglib_aiff/taglib_aiff_wrap.cxx
+++ b/ext/taglib_aiff/taglib_aiff_wrap.cxx
@@ -2092,7 +2092,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_base/taglib_base_wrap.cxx
+++ b/ext/taglib_base/taglib_base_wrap.cxx
@@ -2170,7 +2170,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2223,7 +2223,7 @@ SWIG_From_bool  (bool value)
 }
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_flac/taglib_flac_wrap.cxx
+++ b/ext/taglib_flac/taglib_flac_wrap.cxx
@@ -2102,7 +2102,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
+++ b/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
@@ -2157,7 +2157,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
+++ b/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
@@ -2128,7 +2128,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2185,7 +2185,7 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 }
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -2246,7 +2246,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2299,7 +2299,7 @@ SWIG_From_bool  (bool value)
 }
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2451,7 +2451,7 @@ inline int SWIG_isfinite_func(T x) {
 #endif
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2DBL(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -2154,7 +2154,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2271,7 +2271,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2355,7 +2355,7 @@ SWIG_AsVal_unsigned_SS_char (VALUE obj, unsigned char *val)
 
 
 #ifdef SWIG_LONG_LONG_AVAILABLE
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
+++ b/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
@@ -2182,7 +2182,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_ogg/taglib_ogg_wrap.cxx
+++ b/ext/taglib_ogg/taglib_ogg_wrap.cxx
@@ -2106,7 +2106,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;
@@ -2226,7 +2226,7 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 }
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
+++ b/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
@@ -2095,7 +2095,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/ext/taglib_wav/taglib_wav_wrap.cxx
+++ b/ext/taglib_wav/taglib_wav_wrap.cxx
@@ -2093,7 +2093,7 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/4.1.1/share/swig/4.1.1/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
 {
   VALUE *args = (VALUE *)arg;

--- a/tasks/build.rb
+++ b/tasks/build.rb
@@ -1,0 +1,45 @@
+# frozen-string-literal: true
+
+class Build
+  class << self
+    def plat
+      ENV['PLATFORM'] || 'i386-mingw32'
+    end
+
+    def version
+      ENV['TAGLIB_VERSION'] || '1.9.1'
+    end
+
+    def dir
+      "taglib-#{version}"
+    end
+
+    def tmp
+      "#{__dir__}/../tmp"
+    end
+
+    def source
+      "#{tmp}/#{dir}"
+    end
+
+    def tarball
+      "#{source}.tar.gz"
+    end
+
+    def tmp_arch
+      "#{tmp}/#{plat}"
+    end
+
+    def install_dir
+      "#{tmp_arch}/#{dir}"
+    end
+
+    def build_dir
+      "#{install_dir}-build"
+    end
+
+    def library
+      "#{install_dir}/lib/libtag.#{RbConfig::CONFIG['SOEXT']}"
+    end
+  end
+end

--- a/tasks/build.rb
+++ b/tasks/build.rb
@@ -7,7 +7,7 @@ class Build
     end
 
     def version
-      ENV['TAGLIB_VERSION'] || '1.9.1'
+      ENV['TAGLIB_VERSION'] || '1.11.1'
     end
 
     def dir


### PR DESCRIPTION
This is working towards deterministic `rake swig` (see https://github.com/robinst/taglib-ruby/issues/136).

- let `rake swig` use the taglib installed by `rake vendor`
- use TagLib 1.11.1 in `rake vendor` (the checked-in wrapper files were already based on 1.11.1)
- normalize `@SWIG` comments so they don't depend on where the developer installed swig