### PR TITLE
Revert "Mark *_wrap.cxx as generated"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*_wrap.cxx linguist-generated=true


### PR DESCRIPTION
This reverts commit 59329af986a8d8d753156da91ef6dc1b835ca8dc (PR https://github.com/robinst/taglib-ruby/pull/134).

It turns out this is not great for GitHub PR review ergonomics after all. We want to review _wrap.cxx changes even though they are generated.