### PR TITLE
rake vendor: use git to download taglib

### DIFF
--- a/tasks/build.rb
+++ b/tasks/build.rb
@@ -22,10 +22,6 @@ class Build
       "#{tmp}/#{dir}"
     end
 
-    def tarball
-      "#{source}.tar.gz"
-    end
-
     def tmp_arch
       "#{tmp}/#{plat}"
     end

--- a/tasks/ext.rake
+++ b/tasks/ext.rake
@@ -93,17 +93,8 @@ directory Build.install_dir
 directory Build.build_dir
 directory Build.tmp
 
-file Build.source => [Build.tarball] do
-  chdir Build.tmp do
-    sh "tar xzf #{Build.tarball}"
-  end
-end
-
-file Build.tarball => [Build.tmp] do |t|
-  require 'open-uri'
-  puts "Downloading #{taglib_url}"
-
-  File.open(t.name, 'wb') do |f|
-    IO.copy_stream(URI.open(taglib_url), f)
-  end
+file Build.source do
+  sh "git clone --depth=1 --branch=v#{Build.version} https://github.com/taglib/taglib.git #{Build.source}"
+  sh "git -C #{Build.source} submodule init"
+  sh "git -C #{Build.source} submodule update --depth=1"
 end


### PR DESCRIPTION
This will help with the switch to TagLib 2 because that version has a dependency in a Git submodule. By pulling in the submodule we don't have to install libutfcpp-dev with the system package manager anymore.