### PR TITLE
Get TagLib 2.0.1 working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       MAKEFLAGS: -j2
       PLATFORM: x86_64-linux
-      TAGLIB_VERSION: 1.11.1
+      TAGLIB_VERSION: 2.0.1
       SWIG_DIR: .swig-v4.1.1
 
     steps:

--- a/ext/taglib_aiff/taglib_aiff.i
+++ b/ext/taglib_aiff/taglib_aiff.i
@@ -4,8 +4,6 @@
 #include <taglib/aifffile.h>
 #include <taglib/aiffproperties.h>
 #include <taglib/id3v2tag.h>
-#include <taglib/tpicturetype.h>
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -16,12 +14,16 @@ using namespace TagLib;
 %ignore TagLib::RIFF::AIFF::Properties::length;
 %ignore TagLib::RIFF::AIFF::Properties::sampleWidth;
 
+%ignore TagLib::RIFF::File;
+%include <taglib/rifffile.h>
+
 %include <taglib/aiffproperties.h>
 
 %freefunc TagLib::RIFF::AIFF::File "free_taglib_riff_aiff_file";
 
 // Ignore IOStream and all the constructors using it.
 %ignore IOStream;
+%ignore TagLib::RIFF::AIFF::File::File(IOStream *, bool, Properties::ReadStyle, ID3v2::FrameFactory *);
 %ignore TagLib::RIFF::AIFF::File::File(IOStream *, bool, Properties::ReadStyle);
 %ignore TagLib::RIFF::AIFF::File::File(IOStream *, bool);
 %ignore TagLib::RIFF::AIFF::File::File(IOStream *);

--- a/ext/taglib_aiff/taglib_aiff.i
+++ b/ext/taglib_aiff/taglib_aiff.i
@@ -4,6 +4,8 @@
 #include <taglib/aifffile.h>
 #include <taglib/aiffproperties.h>
 #include <taglib/id3v2tag.h>
+#include <taglib/tpicturetype.h>
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_aiff/taglib_aiff_wrap.cxx
+++ b/ext/taglib_aiff/taglib_aiff_wrap.cxx
@@ -1854,16 +1854,21 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 /* -------- TYPES TABLE (BEGIN) -------- */
 
 #define SWIGTYPE_p_TagLib__AudioProperties swig_types[0]
-#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[1]
-#define SWIGTYPE_p_TagLib__RIFF__AIFF__File swig_types[2]
-#define SWIGTYPE_p_TagLib__RIFF__AIFF__Properties swig_types[3]
-#define SWIGTYPE_p_char swig_types[4]
-#define SWIGTYPE_p_unsigned_char swig_types[5]
-#define SWIGTYPE_p_unsigned_int swig_types[6]
-#define SWIGTYPE_p_unsigned_long swig_types[7]
-#define SWIGTYPE_p_wchar_t swig_types[8]
-static swig_type_info *swig_types[10];
-static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
+#define SWIGTYPE_p_TagLib__File swig_types[1]
+#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[2]
+#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[3]
+#define SWIGTYPE_p_TagLib__ID3v2__Version swig_types[4]
+#define SWIGTYPE_p_TagLib__RIFF__AIFF__File swig_types[5]
+#define SWIGTYPE_p_TagLib__RIFF__AIFF__Properties swig_types[6]
+#define SWIGTYPE_p_TagLib__RIFF__File swig_types[7]
+#define SWIGTYPE_p_char swig_types[8]
+#define SWIGTYPE_p_long_long swig_types[9]
+#define SWIGTYPE_p_unsigned_char swig_types[10]
+#define SWIGTYPE_p_unsigned_int swig_types[11]
+#define SWIGTYPE_p_unsigned_long swig_types[12]
+#define SWIGTYPE_p_wchar_t swig_types[13]
+static swig_type_info *swig_types[15];
+static swig_module_info swig_module = {swig_types, 14, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1957,34 +1962,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2073,6 +2070,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 #include <limits.h>
@@ -2327,30 +2331,6 @@ free_TagLib_RIFF_AIFF_Properties(void *self) {
 }
 
 SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::RIFF::AIFF::Properties *arg1 = (TagLib::RIFF::AIFF::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__RIFF__AIFF__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::RIFF::AIFF::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::RIFF::AIFF::Properties * >(argp1);
-  result = (int)((TagLib::RIFF::AIFF::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
   TagLib::RIFF::AIFF::Properties *arg1 = (TagLib::RIFF::AIFF::Properties *) 0 ;
   void *argp1 = 0 ;
@@ -2577,6 +2557,53 @@ _wrap_new_File__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   TagLib::RIFF::AIFF::Properties::ReadStyle arg3 ;
+  TagLib::ID3v2::FrameFactory *arg4 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  TagLib::RIFF::AIFF::File *result = 0 ;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  {
+    arg1 = ruby_string_to_taglib_filename(argv[0]);
+    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
+      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
+    }
+  }
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","File", 2, argv[1] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::RIFF::AIFF::Properties::ReadStyle","File", 3, argv[2] ));
+  } 
+  arg3 = static_cast< TagLib::RIFF::AIFF::Properties::ReadStyle >(val3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory *","File", 4, argv[3] )); 
+  }
+  arg4 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp4);
+  result = (TagLib::RIFF::AIFF::File *)new TagLib::RIFF::AIFF::File(arg1,arg2,arg3,arg4);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::FileName arg1 ;
+  bool arg2 ;
+  TagLib::RIFF::AIFF::Properties::ReadStyle arg3 ;
   bool val2 ;
   int ecode2 = 0 ;
   int val3 ;
@@ -2612,7 +2639,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   bool val2 ;
@@ -2658,7 +2685,7 @@ _wrap_File_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::RIFF::AIFF::File *result = 0 ;
   
@@ -2682,11 +2709,11 @@ fail:
 
 SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
   int argc;
-  VALUE argv[3];
+  VALUE argv[4];
   int ii;
   
   argc = nargs;
-  if (argc > 3) SWIG_fail;
+  if (argc > 4) SWIG_fail;
   for (ii = 0; (ii < argc); ++ii) {
     argv[ii] = args[ii];
   }
@@ -2695,7 +2722,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_File__SWIG_2(nargs, args, self);
+      return _wrap_new_File__SWIG_3(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -2708,7 +2735,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_File__SWIG_1(nargs, args, self);
+        return _wrap_new_File__SWIG_2(nargs, args, self);
       }
     }
   }
@@ -2727,14 +2754,40 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_0(nargs, args, self);
+          return _wrap_new_File__SWIG_1(nargs, args, self);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_new_File__SWIG_0(nargs, args, self);
+          }
         }
       }
     }
   }
   
 fail:
-  Ruby_Format_OverloadedError( argc, 3, "File.new", 
+  Ruby_Format_OverloadedError( argc, 4, "File.new", 
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::RIFF::AIFF::Properties::ReadStyle propertiesStyle, TagLib::ID3v2::FrameFactory *frameFactory)\n"
     "    File.new(TagLib::FileName file, bool readProperties, TagLib::RIFF::AIFF::Properties::ReadStyle propertiesStyle)\n"
     "    File.new(TagLib::FileName file, bool readProperties)\n"
     "    File.new(TagLib::FileName file)\n");
@@ -2792,7 +2845,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_File_save(int argc, VALUE *argv, VALUE self) {
+_wrap_File_save__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::RIFF::AIFF::File *arg1 = (TagLib::RIFF::AIFF::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2811,6 +2864,88 @@ _wrap_File_save(int argc, VALUE *argv, VALUE self) {
   vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
 fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_save__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::RIFF::AIFF::File *arg1 = (TagLib::RIFF::AIFF::File *) 0 ;
+  TagLib::ID3v2::Version arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__RIFF__AIFF__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::RIFF::AIFF::File *","save", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::RIFF::AIFF::File * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_TagLib__ID3v2__Version,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::ID3v2::Version","save", 2, argv[0] )); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::ID3v2::Version","save", 2, argv[0]));
+    } else {
+      arg2 = *(reinterpret_cast< TagLib::ID3v2::Version * >(argp2));
+    }
+  }
+  result = (bool)(arg1)->save(arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[3];
+  int ii;
+  
+  argc = nargs + 1;
+  argv[0] = self;
+  if (argc > 3) SWIG_fail;
+  for (ii = 1; (ii < argc); ++ii) {
+    argv[ii] = args[ii-1];
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__RIFF__AIFF__File, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_File_save__SWIG_0(nargs, args, self);
+    }
+  }
+  if (argc == 2) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__RIFF__AIFF__File, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__ID3v2__Version, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_File_save__SWIG_1(nargs, args, self);
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 3, "File.save", 
+    "    bool File.save()\n"
+    "    bool File.save(TagLib::ID3v2::Version version)\n");
+  
   return Qnil;
 }
 
@@ -2866,11 +3001,25 @@ fail:
 static void *_p_TagLib__RIFF__AIFF__PropertiesTo_p_TagLib__AudioProperties(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((TagLib::AudioProperties *)  ((TagLib::RIFF::AIFF::Properties *) x));
 }
+static void *_p_TagLib__RIFF__AIFF__FileTo_p_TagLib__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::File *) (TagLib::RIFF::File *) ((TagLib::RIFF::AIFF::File *) x));
+}
+static void *_p_TagLib__RIFF__FileTo_p_TagLib__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::File *)  ((TagLib::RIFF::File *) x));
+}
+static void *_p_TagLib__RIFF__AIFF__FileTo_p_TagLib__RIFF__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::RIFF::File *)  ((TagLib::RIFF::AIFF::File *) x));
+}
 static swig_type_info _swigt__p_TagLib__AudioProperties = {"_p_TagLib__AudioProperties", "TagLib::AudioProperties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__File = {"_p_TagLib__File", "TagLib::File *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__ID3v2__FrameFactory = {"_p_TagLib__ID3v2__FrameFactory", "TagLib::ID3v2::FrameFactory *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__Tag = {"_p_TagLib__ID3v2__Tag", "TagLib::ID3v2::Tag *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__ID3v2__Version = {"_p_TagLib__ID3v2__Version", "TagLib::ID3v2::Version *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__RIFF__AIFF__File = {"_p_TagLib__RIFF__AIFF__File", "TagLib::RIFF::AIFF::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__RIFF__AIFF__Properties = {"_p_TagLib__RIFF__AIFF__Properties", "TagLib::RIFF::AIFF::Properties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__RIFF__File = {"_p_TagLib__RIFF__File", "TagLib::RIFF::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -2878,10 +3027,15 @@ static swig_type_info _swigt__p_wchar_t = {"_p_wchar_t", "TagLib::wchar *|wchar_
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__AudioProperties,
+  &_swigt__p_TagLib__File,
+  &_swigt__p_TagLib__ID3v2__FrameFactory,
   &_swigt__p_TagLib__ID3v2__Tag,
+  &_swigt__p_TagLib__ID3v2__Version,
   &_swigt__p_TagLib__RIFF__AIFF__File,
   &_swigt__p_TagLib__RIFF__AIFF__Properties,
+  &_swigt__p_TagLib__RIFF__File,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -2889,10 +3043,15 @@ static swig_type_info *swig_type_initial[] = {
 };
 
 static swig_cast_info _swigc__p_TagLib__AudioProperties[] = {  {&_swigt__p_TagLib__AudioProperties, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__AIFF__Properties, _p_TagLib__RIFF__AIFF__PropertiesTo_p_TagLib__AudioProperties, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__File[] = {  {&_swigt__p_TagLib__File, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__AIFF__File, _p_TagLib__RIFF__AIFF__FileTo_p_TagLib__File, 0, 0},  {&_swigt__p_TagLib__RIFF__File, _p_TagLib__RIFF__FileTo_p_TagLib__File, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__ID3v2__FrameFactory[] = {  {&_swigt__p_TagLib__ID3v2__FrameFactory, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__Tag[] = {  {&_swigt__p_TagLib__ID3v2__Tag, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__ID3v2__Version[] = {  {&_swigt__p_TagLib__ID3v2__Version, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__RIFF__AIFF__File[] = {  {&_swigt__p_TagLib__RIFF__AIFF__File, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__RIFF__AIFF__Properties[] = {  {&_swigt__p_TagLib__RIFF__AIFF__Properties, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__RIFF__File[] = {  {&_swigt__p_TagLib__RIFF__File, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__AIFF__File, _p_TagLib__RIFF__AIFF__FileTo_p_TagLib__RIFF__File, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -2900,10 +3059,15 @@ static swig_cast_info _swigc__p_wchar_t[] = {  {&_swigt__p_wchar_t, 0, 0, 0},{0,
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__AudioProperties,
+  _swigc__p_TagLib__File,
+  _swigc__p_TagLib__ID3v2__FrameFactory,
   _swigc__p_TagLib__ID3v2__Tag,
+  _swigc__p_TagLib__ID3v2__Version,
   _swigc__p_TagLib__RIFF__AIFF__File,
   _swigc__p_TagLib__RIFF__AIFF__Properties,
+  _swigc__p_TagLib__RIFF__File,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -3173,7 +3337,6 @@ SWIGEXPORT void Init_taglib_aiff(void) {
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__RIFF__AIFF__Properties, (void *) &SwigClassProperties);
   rb_define_alloc_func(SwigClassProperties.klass, _wrap_Properties_allocate);
   rb_define_method(SwigClassProperties.klass, "initialize", VALUEFUNC(_wrap_new_Properties), -1);
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);

--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -5,6 +5,7 @@
 #define TAGLIB_IGNORE_MISSING_DESTRUCTOR
 #define TAGLIB_DEPRECATED
 #define TAGLIB_MSVC_SUPPRESS_WARNING_NEEDS_TO_HAVE_DLL_INTERFACE
+%include <taglib/tpicturetype.h>
 
 // Replaces the typemap from swigtype.swg and just adds the line
 // SWIG_RubyUnlinkObjects. This is done to be safe in the case when a
@@ -24,6 +25,7 @@
 #include <taglib/tbytevector.h>
 #include <taglib/tbytevectorlist.h>
 #include <taglib/tfile.h>
+#include <taglib/tvariant.h>
 
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
@@ -37,34 +39,26 @@
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }

--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -5,7 +5,6 @@
 #define TAGLIB_IGNORE_MISSING_DESTRUCTOR
 #define TAGLIB_DEPRECATED
 #define TAGLIB_MSVC_SUPPRESS_WARNING_NEEDS_TO_HAVE_DLL_INTERFACE
-%include <taglib/tpicturetype.h>
 
 // Replaces the typemap from swigtype.swg and just adds the line
 // SWIG_RubyUnlinkObjects. This is done to be safe in the case when a
@@ -25,7 +24,6 @@
 #include <taglib/tbytevector.h>
 #include <taglib/tbytevectorlist.h>
 #include <taglib/tfile.h>
-#include <taglib/tvariant.h>
 
 #if defined(HAVE_RUBY_ENCODING_H) && HAVE_RUBY_ENCODING_H
 # include <ruby/encoding.h>
@@ -147,6 +145,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 %}
 
 // vim: set filetype=cpp sw=2 ts=2 expandtab:

--- a/ext/taglib_base/includes.i
+++ b/ext/taglib_base/includes.i
@@ -4,6 +4,7 @@
 #define TAGLIB_EXPORT
 #define TAGLIB_IGNORE_MISSING_DESTRUCTOR
 #define TAGLIB_DEPRECATED
+#define TAGLIB_MSVC_SUPPRESS_WARNING_NEEDS_TO_HAVE_DLL_INTERFACE
 
 // Replaces the typemap from swigtype.swg and just adds the line
 // SWIG_RubyUnlinkObjects. This is done to be safe in the case when a

--- a/ext/taglib_base/taglib_base.i
+++ b/ext/taglib_base/taglib_base.i
@@ -6,6 +6,10 @@
 #include <taglib/tlist.h>
 #include <taglib/fileref.h>
 #include <taglib/tag.h>
+#include <taglib/tpropertymap.h>
+#include <taglib/tvariant.h>
+#include <taglib/tpicturetype.h>
+using namespace TagLib;
 %}
 
 %include "includes.i"

--- a/ext/taglib_base/taglib_base.i
+++ b/ext/taglib_base/taglib_base.i
@@ -6,10 +6,6 @@
 #include <taglib/tlist.h>
 #include <taglib/fileref.h>
 #include <taglib/tag.h>
-#include <taglib/tpropertymap.h>
-#include <taglib/tvariant.h>
-#include <taglib/tpicturetype.h>
-using namespace TagLib;
 %}
 
 %include "includes.i"
@@ -30,6 +26,7 @@ namespace TagLib {
   typedef unsigned char uchar;
   typedef unsigned int  uint;
   typedef unsigned long ulong;
+  using offset_t = long long;
 }
 
 %constant int TAGLIB_MAJOR_VERSION = TAGLIB_MAJOR_VERSION;
@@ -129,6 +126,10 @@ namespace TagLib {
 %typemap(typecheck) TagLib::FileName = char *;
 %feature("valuewrapper") TagLib::FileName;
 
+%typemap(out) TagLib::offset_t {
+  $result = taglib_offset_t_to_ruby_int($1);
+}
+
 %ignore TagLib::List::operator[];
 %ignore TagLib::List::operator=;
 %ignore TagLib::List::operator!=;
@@ -138,6 +139,10 @@ namespace TagLib {
 %ignore TagLib::Tag::properties;
 %ignore TagLib::Tag::setProperties;
 %ignore TagLib::Tag::removeUnsupportedProperties;
+
+%ignore TagLib::Tag::complexProperties;
+%ignore TagLib::Tag::setComplexProperties;
+%ignore TagLib::Tag::complexPropertyKeys;
 
 %include <taglib/tag.h>
 
@@ -151,7 +156,19 @@ namespace TagLib {
 %ignore TagLib::File::setProperties;
 %ignore TagLib::File::removeUnsupportedProperties;
 
+%ignore TagLib::File::complexProperties;
+%ignore TagLib::File::setComplexProperties;
+%ignore TagLib::File::complexPropertyKeys;
+
 %include <taglib/tfile.h>
+
+%ignore TagLib::FileRef::properties;
+%ignore TagLib::FileRef::setProperties;
+%ignore TagLib::FileRef::removeUnsupportedProperties;
+
+%ignore TagLib::FileRef::complexProperties;
+%ignore TagLib::FileRef::setComplexProperties;
+%ignore TagLib::FileRef::complexPropertyKeys;
 
 // Ignore IOStream and all the constructors using it.
 %ignore IOStream;

--- a/ext/taglib_base/taglib_base_wrap.cxx
+++ b/ext/taglib_base/taglib_base_wrap.cxx
@@ -1860,12 +1860,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__String swig_types[4]
 #define SWIGTYPE_p_TagLib__Tag swig_types[5]
 #define SWIGTYPE_p_char swig_types[6]
-#define SWIGTYPE_p_unsigned_char swig_types[7]
-#define SWIGTYPE_p_unsigned_int swig_types[8]
-#define SWIGTYPE_p_unsigned_long swig_types[9]
-#define SWIGTYPE_p_wchar_t swig_types[10]
-static swig_type_info *swig_types[12];
-static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[7]
+#define SWIGTYPE_p_unsigned_char swig_types[8]
+#define SWIGTYPE_p_unsigned_int swig_types[9]
+#define SWIGTYPE_p_unsigned_long swig_types[10]
+#define SWIGTYPE_p_wchar_t swig_types[11]
+static swig_type_info *swig_types[13];
+static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1961,34 +1962,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2077,6 +2070,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 #include <limits.h>
@@ -2287,6 +2287,96 @@ SWIG_AsVal_bool (VALUE obj, bool *val)
   }  
   return SWIG_TypeError;
 }
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2ULL(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2ULL(obj) : rb_big2ull(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_long_SS_long (VALUE obj, unsigned long long *val)
+{ 
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    unsigned long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2ULL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
+}
+#endif
+
+
+SWIGINTERNINLINE int
+SWIG_AsVal_size_t (VALUE obj, size_t *val)
+{
+  int res = SWIG_TypeError;
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    unsigned long v;
+    res = SWIG_AsVal_unsigned_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else if (sizeof(size_t) <= sizeof(unsigned long long)) {
+    unsigned long long v;
+    res = SWIG_AsVal_unsigned_SS_long_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+  }
+#endif
+  return res;
+}
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (VALUE obj, long long *val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
+}
+#endif
 
 SWIGINTERN void TagLib_FileRef_close(TagLib::FileRef *self){
     free_taglib_fileref(self);
@@ -2877,6 +2967,30 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_Tag_join_tag_values(int argc, VALUE *argv, VALUE self) {
+  TagLib::StringList *arg1 = 0 ;
+  TagLib::StringList tmp1 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_string_list(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = TagLib::Tag::joinTagValues((TagLib::StringList const &)*arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassAudioProperties;
 
 SWIGINTERN void
@@ -3116,10 +3230,10 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_read_block(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  unsigned long arg2 ;
+  size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned long val2 ;
+  size_t val2 ;
   int ecode2 = 0 ;
   TagLib::ByteVector result;
   VALUE vresult = Qnil;
@@ -3132,11 +3246,11 @@ _wrap_File_read_block(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","readBlock", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_unsigned_SS_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_size_t(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "unsigned long","readBlock", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "size_t","readBlock", 2, argv[0] ));
   } 
-  arg2 = static_cast< unsigned long >(val2);
+  arg2 = static_cast< size_t >(val2);
   result = (arg1)->readBlock(arg2);
   {
     vresult = taglib_bytevector_to_ruby_string(result);
@@ -3178,9 +3292,9 @@ fail:
   Document-method: TagLib::File.find
 
   call-seq:
-    find(pattern, fromOffset=0, before=TagLib::ByteVector()) -> long
-    find(pattern, fromOffset=0) -> long
-    find(pattern) -> long
+    find(pattern, fromOffset=0, before=TagLib::ByteVector()) -> TagLib::offset_t
+    find(pattern, fromOffset=0) -> TagLib::offset_t
+    find(pattern) -> TagLib::offset_t
 
 Find an element in the class.
 */
@@ -3188,15 +3302,15 @@ SWIGINTERN VALUE
 _wrap_File_find__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  long arg3 ;
+  TagLib::offset_t arg3 ;
   TagLib::ByteVector *arg4 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
   TagLib::ByteVector tmp4 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 3) || (argc > 3)) {
@@ -3211,17 +3325,19 @@ _wrap_File_find__SWIG_0(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "long","find", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","find", 3, argv[1] ));
   } 
-  arg3 = static_cast< long >(val3);
+  arg3 = static_cast< TagLib::offset_t >(val3);
   {
     tmp4 = ruby_string_to_taglib_bytevector(argv[2]);
     arg4 = &tmp4;
   }
-  result = (long)(arg1)->find((TagLib::ByteVector const &)*arg2,arg3,(TagLib::ByteVector const &)*arg4);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->find((TagLib::ByteVector const &)*arg2,arg3,(TagLib::ByteVector const &)*arg4);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3232,13 +3348,13 @@ SWIGINTERN VALUE
 _wrap_File_find__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  long arg3 ;
+  TagLib::offset_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 2) || (argc > 2)) {
@@ -3253,13 +3369,15 @@ _wrap_File_find__SWIG_1(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "long","find", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","find", 3, argv[1] ));
   } 
-  arg3 = static_cast< long >(val3);
-  result = (long)(arg1)->find((TagLib::ByteVector const &)*arg2,arg3);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  arg3 = static_cast< TagLib::offset_t >(val3);
+  result = (TagLib::offset_t)(arg1)->find((TagLib::ByteVector const &)*arg2,arg3);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3273,7 +3391,7 @@ _wrap_File_find__SWIG_2(int argc, VALUE *argv, VALUE self) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -3288,8 +3406,10 @@ _wrap_File_find__SWIG_2(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  result = (long)(arg1)->find((TagLib::ByteVector const &)*arg2);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->find((TagLib::ByteVector const &)*arg2);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3330,7 +3450,7 @@ SWIGINTERN VALUE _wrap_File_find(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3349,7 +3469,7 @@ SWIGINTERN VALUE _wrap_File_find(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3365,9 +3485,9 @@ SWIGINTERN VALUE _wrap_File_find(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 5, "File.find", 
-    "    long File.find(TagLib::ByteVector const &pattern, long fromOffset, TagLib::ByteVector const &before)\n"
-    "    long File.find(TagLib::ByteVector const &pattern, long fromOffset)\n"
-    "    long File.find(TagLib::ByteVector const &pattern)\n");
+    "    TagLib::offset_t File.find(TagLib::ByteVector const &pattern, TagLib::offset_t fromOffset, TagLib::ByteVector const &before)\n"
+    "    TagLib::offset_t File.find(TagLib::ByteVector const &pattern, TagLib::offset_t fromOffset)\n"
+    "    TagLib::offset_t File.find(TagLib::ByteVector const &pattern)\n");
   
   return Qnil;
 }
@@ -3377,15 +3497,15 @@ SWIGINTERN VALUE
 _wrap_File_rfind__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  long arg3 ;
+  TagLib::offset_t arg3 ;
   TagLib::ByteVector *arg4 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
   TagLib::ByteVector tmp4 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 3) || (argc > 3)) {
@@ -3400,17 +3520,19 @@ _wrap_File_rfind__SWIG_0(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "long","rfind", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","rfind", 3, argv[1] ));
   } 
-  arg3 = static_cast< long >(val3);
+  arg3 = static_cast< TagLib::offset_t >(val3);
   {
     tmp4 = ruby_string_to_taglib_bytevector(argv[2]);
     arg4 = &tmp4;
   }
-  result = (long)(arg1)->rfind((TagLib::ByteVector const &)*arg2,arg3,(TagLib::ByteVector const &)*arg4);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->rfind((TagLib::ByteVector const &)*arg2,arg3,(TagLib::ByteVector const &)*arg4);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3421,13 +3543,13 @@ SWIGINTERN VALUE
 _wrap_File_rfind__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  long arg3 ;
+  TagLib::offset_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 2) || (argc > 2)) {
@@ -3442,13 +3564,15 @@ _wrap_File_rfind__SWIG_1(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "long","rfind", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","rfind", 3, argv[1] ));
   } 
-  arg3 = static_cast< long >(val3);
-  result = (long)(arg1)->rfind((TagLib::ByteVector const &)*arg2,arg3);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  arg3 = static_cast< TagLib::offset_t >(val3);
+  result = (TagLib::offset_t)(arg1)->rfind((TagLib::ByteVector const &)*arg2,arg3);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3462,7 +3586,7 @@ _wrap_File_rfind__SWIG_2(int argc, VALUE *argv, VALUE self) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -3477,8 +3601,10 @@ _wrap_File_rfind__SWIG_2(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  result = (long)(arg1)->rfind((TagLib::ByteVector const &)*arg2);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->rfind((TagLib::ByteVector const &)*arg2);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -3519,7 +3645,7 @@ SWIGINTERN VALUE _wrap_File_rfind(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3538,7 +3664,7 @@ SWIGINTERN VALUE _wrap_File_rfind(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3554,9 +3680,9 @@ SWIGINTERN VALUE _wrap_File_rfind(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 5, "File.rfind", 
-    "    long File.rfind(TagLib::ByteVector const &pattern, long fromOffset, TagLib::ByteVector const &before)\n"
-    "    long File.rfind(TagLib::ByteVector const &pattern, long fromOffset)\n"
-    "    long File.rfind(TagLib::ByteVector const &pattern)\n");
+    "    TagLib::offset_t File.rfind(TagLib::ByteVector const &pattern, TagLib::offset_t fromOffset, TagLib::ByteVector const &before)\n"
+    "    TagLib::offset_t File.rfind(TagLib::ByteVector const &pattern, TagLib::offset_t fromOffset)\n"
+    "    TagLib::offset_t File.rfind(TagLib::ByteVector const &pattern)\n");
   
   return Qnil;
 }
@@ -3576,14 +3702,14 @@ SWIGINTERN VALUE
 _wrap_File_insert__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  unsigned long arg3 ;
-  unsigned long arg4 ;
+  TagLib::offset_t arg3 ;
+  size_t arg4 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  unsigned long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
-  unsigned long val4 ;
+  size_t val4 ;
   int ecode4 = 0 ;
   
   if ((argc < 3) || (argc > 3)) {
@@ -3598,16 +3724,16 @@ _wrap_File_insert__SWIG_0(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_unsigned_SS_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "unsigned long","insert", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","insert", 3, argv[1] ));
   } 
-  arg3 = static_cast< unsigned long >(val3);
-  ecode4 = SWIG_AsVal_unsigned_SS_long(argv[2], &val4);
+  arg3 = static_cast< TagLib::offset_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(argv[2], &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "unsigned long","insert", 4, argv[2] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "size_t","insert", 4, argv[2] ));
   } 
-  arg4 = static_cast< unsigned long >(val4);
+  arg4 = static_cast< size_t >(val4);
   (arg1)->insert((TagLib::ByteVector const &)*arg2,arg3,arg4);
   return Qnil;
 fail:
@@ -3619,11 +3745,11 @@ SWIGINTERN VALUE
 _wrap_File_insert__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
-  unsigned long arg3 ;
+  TagLib::offset_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   TagLib::ByteVector tmp2 ;
-  unsigned long val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
   
   if ((argc < 2) || (argc > 2)) {
@@ -3638,11 +3764,11 @@ _wrap_File_insert__SWIG_1(int argc, VALUE *argv, VALUE self) {
     tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
     arg2 = &tmp2;
   }
-  ecode3 = SWIG_AsVal_unsigned_SS_long(argv[1], &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "unsigned long","insert", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::offset_t","insert", 3, argv[1] ));
   } 
-  arg3 = static_cast< unsigned long >(val3);
+  arg3 = static_cast< TagLib::offset_t >(val3);
   (arg1)->insert((TagLib::ByteVector const &)*arg2,arg3);
   return Qnil;
 fail:
@@ -3711,7 +3837,7 @@ SWIGINTERN VALUE _wrap_File_insert(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_unsigned_SS_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3730,12 +3856,12 @@ SWIGINTERN VALUE _wrap_File_insert(int nargs, VALUE *args, VALUE self) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_unsigned_SS_long(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
           {
-            int res = SWIG_AsVal_unsigned_SS_long(argv[3], NULL);
+            int res = SWIG_AsVal_size_t(argv[3], NULL);
             _v = SWIG_CheckState(res);
           }
           if (_v) {
@@ -3748,8 +3874,8 @@ SWIGINTERN VALUE _wrap_File_insert(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 5, "File.insert", 
-    "    void File.insert(TagLib::ByteVector const &data, unsigned long start, unsigned long replace)\n"
-    "    void File.insert(TagLib::ByteVector const &data, unsigned long start)\n"
+    "    void File.insert(TagLib::ByteVector const &data, TagLib::offset_t start, size_t replace)\n"
+    "    void File.insert(TagLib::ByteVector const &data, TagLib::offset_t start)\n"
     "    void File.insert(TagLib::ByteVector const &data)\n");
   
   return Qnil;
@@ -3759,13 +3885,13 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_remove_block__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  unsigned long arg2 ;
-  unsigned long arg3 ;
+  TagLib::offset_t arg2 ;
+  size_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
-  unsigned long val3 ;
+  size_t val3 ;
   int ecode3 = 0 ;
   
   if ((argc < 2) || (argc > 2)) {
@@ -3776,16 +3902,16 @@ _wrap_File_remove_block__SWIG_0(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","removeBlock", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_unsigned_SS_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "unsigned long","removeBlock", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","removeBlock", 2, argv[0] ));
   } 
-  arg2 = static_cast< unsigned long >(val2);
-  ecode3 = SWIG_AsVal_unsigned_SS_long(argv[1], &val3);
+  arg2 = static_cast< TagLib::offset_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "unsigned long","removeBlock", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "size_t","removeBlock", 3, argv[1] ));
   } 
-  arg3 = static_cast< unsigned long >(val3);
+  arg3 = static_cast< size_t >(val3);
   (arg1)->removeBlock(arg2,arg3);
   return Qnil;
 fail:
@@ -3796,10 +3922,10 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_remove_block__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  unsigned long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   
   if ((argc < 1) || (argc > 1)) {
@@ -3810,11 +3936,11 @@ _wrap_File_remove_block__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","removeBlock", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_unsigned_SS_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "unsigned long","removeBlock", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","removeBlock", 2, argv[0] ));
   } 
-  arg2 = static_cast< unsigned long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   (arg1)->removeBlock(arg2);
   return Qnil;
 fail:
@@ -3870,7 +3996,7 @@ SWIGINTERN VALUE _wrap_File_remove_block(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_unsigned_SS_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -3885,12 +4011,12 @@ SWIGINTERN VALUE _wrap_File_remove_block(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_unsigned_SS_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_unsigned_SS_long(argv[2], NULL);
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3902,8 +4028,8 @@ SWIGINTERN VALUE _wrap_File_remove_block(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 4, "File.remove_block", 
-    "    void File.remove_block(unsigned long start, unsigned long length)\n"
-    "    void File.remove_block(unsigned long start)\n"
+    "    void File.remove_block(TagLib::offset_t start, size_t length)\n"
+    "    void File.remove_block(TagLib::offset_t start)\n"
     "    void File.remove_block()\n");
   
   return Qnil;
@@ -3985,11 +4111,11 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_seek__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   TagLib::File::Position arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -4002,11 +4128,11 @@ _wrap_File_seek__SWIG_0(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","seek", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","seek", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","seek", 2, argv[0] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   ecode3 = SWIG_AsVal_int(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::Position","seek", 3, argv[1] ));
@@ -4022,10 +4148,10 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_seek__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   
   if ((argc < 1) || (argc > 1)) {
@@ -4036,11 +4162,11 @@ _wrap_File_seek__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","seek", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","seek", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","seek", 2, argv[0] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   (arg1)->seek(arg2);
   return Qnil;
 fail:
@@ -4066,7 +4192,7 @@ SWIGINTERN VALUE _wrap_File_seek(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -4081,7 +4207,7 @@ SWIGINTERN VALUE _wrap_File_seek(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -4098,8 +4224,8 @@ SWIGINTERN VALUE _wrap_File_seek(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 4, "File.seek", 
-    "    void File.seek(long offset, TagLib::File::Position p)\n"
-    "    void File.seek(long offset)\n");
+    "    void File.seek(TagLib::offset_t offset, TagLib::File::Position p)\n"
+    "    void File.seek(TagLib::offset_t offset)\n");
   
   return Qnil;
 }
@@ -4131,7 +4257,7 @@ _wrap_File_tell(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -4142,8 +4268,10 @@ _wrap_File_tell(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File const *","tell", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  result = (long)((TagLib::File const *)arg1)->tell();
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)((TagLib::File const *)arg1)->tell();
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -4155,7 +4283,7 @@ _wrap_File_length(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -4166,64 +4294,12 @@ _wrap_File_length(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","length", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  result = (long)(arg1)->length();
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->length();
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_readableq___(int argc, VALUE *argv, VALUE self) {
-  char *arg1 = (char *) 0 ;
-  int res1 ;
-  char *buf1 = 0 ;
-  int alloc1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_AsCharPtrAndSize(argv[0], &buf1, NULL, &alloc1);
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "char const *","TagLib::File::isReadable", 1, argv[0] ));
-  }
-  arg1 = reinterpret_cast< char * >(buf1);
-  result = (bool)TagLib::File::isReadable((char const *)arg1);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
-  return vresult;
-fail:
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_writableq___(int argc, VALUE *argv, VALUE self) {
-  char *arg1 = (char *) 0 ;
-  int res1 ;
-  char *buf1 = 0 ;
-  int alloc1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_AsCharPtrAndSize(argv[0], &buf1, NULL, &alloc1);
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "char const *","TagLib::File::isWritable", 1, argv[0] ));
-  }
-  arg1 = reinterpret_cast< char * >(buf1);
-  result = (bool)TagLib::File::isWritable((char const *)arg1);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
-  return vresult;
-fail:
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
   return Qnil;
 }
 
@@ -4620,6 +4696,18 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_FileRef_clear_file_type_resolvers(int argc, VALUE *argv, VALUE self) {
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  TagLib::FileRef::clearFileTypeResolvers();
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_FileRef_default_file_extensions(int argc, VALUE *argv, VALUE self) {
   TagLib::StringList result;
   VALUE vresult = Qnil;
@@ -4705,162 +4793,6 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_FileRef_create__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::FileName arg1 ;
-  bool arg2 ;
-  TagLib::AudioProperties::ReadStyle arg3 ;
-  bool val2 ;
-  int ecode2 = 0 ;
-  int val3 ;
-  int ecode3 = 0 ;
-  TagLib::File *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 3) || (argc > 3)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
-  }
-  {
-    arg1 = ruby_string_to_taglib_filename(argv[0]);
-    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
-      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
-    }
-  }
-  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","TagLib::FileRef::create", 2, argv[1] ));
-  } 
-  arg2 = static_cast< bool >(val2);
-  ecode3 = SWIG_AsVal_int(argv[2], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::AudioProperties::ReadStyle","TagLib::FileRef::create", 3, argv[2] ));
-  } 
-  arg3 = static_cast< TagLib::AudioProperties::ReadStyle >(val3);
-  result = (TagLib::File *)TagLib::FileRef::create(SWIG_STD_MOVE(arg1),arg2,arg3);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__File, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_FileRef_create__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::FileName arg1 ;
-  bool arg2 ;
-  bool val2 ;
-  int ecode2 = 0 ;
-  TagLib::File *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  {
-    arg1 = ruby_string_to_taglib_filename(argv[0]);
-    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
-      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
-    }
-  }
-  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","TagLib::FileRef::create", 2, argv[1] ));
-  } 
-  arg2 = static_cast< bool >(val2);
-  result = (TagLib::File *)TagLib::FileRef::create(SWIG_STD_MOVE(arg1),arg2);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__File, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_FileRef_create__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::FileName arg1 ;
-  TagLib::File *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    arg1 = ruby_string_to_taglib_filename(argv[0]);
-    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
-      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
-    }
-  }
-  result = (TagLib::File *)TagLib::FileRef::create(SWIG_STD_MOVE(arg1));
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__File, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE _wrap_FileRef_create(int nargs, VALUE *args, VALUE self) {
-  int argc;
-  VALUE argv[3];
-  int ii;
-  
-  argc = nargs;
-  if (argc > 3) SWIG_fail;
-  for (ii = 0; (ii < argc); ++ii) {
-    argv[ii] = args[ii];
-  }
-  if (argc == 1) {
-    int _v = 0;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_FileRef_create__SWIG_2(nargs, args, self);
-    }
-  }
-  if (argc == 2) {
-    int _v = 0;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_bool(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_FileRef_create__SWIG_1(nargs, args, self);
-      }
-    }
-  }
-  if (argc == 3) {
-    int _v = 0;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_bool(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        {
-          int res = SWIG_AsVal_int(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_FileRef_create__SWIG_0(nargs, args, self);
-        }
-      }
-    }
-  }
-  
-fail:
-  Ruby_Format_OverloadedError( argc, 3, "FileRef.create", 
-    "    TagLib::File FileRef.create(TagLib::FileName fileName, bool readAudioProperties, TagLib::AudioProperties::ReadStyle audioPropertiesStyle)\n"
-    "    TagLib::File FileRef.create(TagLib::FileName fileName, bool readAudioProperties)\n"
-    "    TagLib::File * FileRef.create(TagLib::FileName fileName)\n");
-  
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_FileRef_close(int argc, VALUE *argv, VALUE self) {
   TagLib::FileRef *arg1 = (TagLib::FileRef *) 0 ;
   void *argp1 = 0 ;
@@ -4891,6 +4823,7 @@ static swig_type_info _swigt__p_TagLib__FileRef__FileTypeResolver = {"_p_TagLib_
 static swig_type_info _swigt__p_TagLib__String = {"_p_TagLib__String", "TagLib::String *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -4904,6 +4837,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__String,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -4917,6 +4851,7 @@ static swig_cast_info _swigc__p_TagLib__FileRef__FileTypeResolver[] = {  {&_swig
 static swig_cast_info _swigc__p_TagLib__String[] = {  {&_swigt__p_TagLib__String, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -4930,6 +4865,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__String,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -5227,6 +5163,7 @@ SWIGEXPORT void Init_taglib_base(void) {
   rb_define_method(SwigClassTag.klass, "track=", VALUEFUNC(_wrap_Tag_tracke___), -1);
   rb_define_method(SwigClassTag.klass, "empty?", VALUEFUNC(_wrap_Tag_emptyq___), -1);
   rb_define_singleton_method(SwigClassTag.klass, "duplicate", VALUEFUNC(_wrap_Tag_duplicate), -1);
+  rb_define_singleton_method(SwigClassTag.klass, "join_tag_values", VALUEFUNC(_wrap_Tag_join_tag_values), -1);
   SwigClassTag.mark = 0;
   SwigClassTag.destroy = (void (*)(void *)) free_TagLib_Tag;
   SwigClassTag.trackObjects = 1;
@@ -5252,6 +5189,10 @@ SWIGEXPORT void Init_taglib_base(void) {
   rb_define_const(SwigClassFile.klass, "Beginning", SWIG_From_int(static_cast< int >(TagLib::File::Beginning)));
   rb_define_const(SwigClassFile.klass, "Current", SWIG_From_int(static_cast< int >(TagLib::File::Current)));
   rb_define_const(SwigClassFile.klass, "End", SWIG_From_int(static_cast< int >(TagLib::File::End)));
+  rb_define_const(SwigClassFile.klass, "StripNone", SWIG_From_int(static_cast< int >(TagLib::File::StripNone)));
+  rb_define_const(SwigClassFile.klass, "StripOthers", SWIG_From_int(static_cast< int >(TagLib::File::StripOthers)));
+  rb_define_const(SwigClassFile.klass, "Duplicate", SWIG_From_int(static_cast< int >(TagLib::File::Duplicate)));
+  rb_define_const(SwigClassFile.klass, "DoNotDuplicate", SWIG_From_int(static_cast< int >(TagLib::File::DoNotDuplicate)));
   rb_define_method(SwigClassFile.klass, "name", VALUEFUNC(_wrap_File_name), -1);
   rb_define_method(SwigClassFile.klass, "tag", VALUEFUNC(_wrap_File_tag), -1);
   rb_define_method(SwigClassFile.klass, "audio_properties", VALUEFUNC(_wrap_File_audio_properties), -1);
@@ -5269,8 +5210,6 @@ SWIGEXPORT void Init_taglib_base(void) {
   rb_define_method(SwigClassFile.klass, "clear", VALUEFUNC(_wrap_File_clear), -1);
   rb_define_method(SwigClassFile.klass, "tell", VALUEFUNC(_wrap_File_tell), -1);
   rb_define_method(SwigClassFile.klass, "length", VALUEFUNC(_wrap_File_length), -1);
-  rb_define_singleton_method(SwigClassFile.klass, "readable?", VALUEFUNC(_wrap_File_readableq___), -1);
-  rb_define_singleton_method(SwigClassFile.klass, "writable?", VALUEFUNC(_wrap_File_writableq___), -1);
   SwigClassFile.mark = 0;
   SwigClassFile.destroy = (void (*)(void *)) free_TagLib_File;
   SwigClassFile.trackObjects = 1;
@@ -5284,10 +5223,10 @@ SWIGEXPORT void Init_taglib_base(void) {
   rb_define_method(SwigClassFileRef.klass, "file", VALUEFUNC(_wrap_FileRef_file), -1);
   rb_define_method(SwigClassFileRef.klass, "save", VALUEFUNC(_wrap_FileRef_save), -1);
   rb_define_singleton_method(SwigClassFileRef.klass, "add_file_type_resolver", VALUEFUNC(_wrap_FileRef_add_file_type_resolver), -1);
+  rb_define_singleton_method(SwigClassFileRef.klass, "clear_file_type_resolvers", VALUEFUNC(_wrap_FileRef_clear_file_type_resolvers), -1);
   rb_define_singleton_method(SwigClassFileRef.klass, "default_file_extensions", VALUEFUNC(_wrap_FileRef_default_file_extensions), -1);
   rb_define_method(SwigClassFileRef.klass, "null?", VALUEFUNC(_wrap_FileRef_nullq___), -1);
   rb_define_method(SwigClassFileRef.klass, "==", VALUEFUNC(_wrap_FileRef___eq__), -1);
-  rb_define_singleton_method(SwigClassFileRef.klass, "create", VALUEFUNC(_wrap_FileRef_create), -1);
   rb_define_method(SwigClassFileRef.klass, "close", VALUEFUNC(_wrap_FileRef_close), -1);
   SwigClassFileRef.mark = 0;
   SwigClassFileRef.destroy = (void (*)(void *)) free_TagLib_FileRef;

--- a/ext/taglib_flac/taglib_flac.i
+++ b/ext/taglib_flac/taglib_flac.i
@@ -5,6 +5,7 @@
 #include <taglib/flacproperties.h>
 #include <taglib/id3v1tag.h>
 #include <taglib/id3v2tag.h>
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_flac/taglib_flac.i
+++ b/ext/taglib_flac/taglib_flac.i
@@ -5,7 +5,6 @@
 #include <taglib/flacproperties.h>
 #include <taglib/id3v1tag.h>
 #include <taglib/id3v2tag.h>
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -21,9 +20,13 @@ using namespace TagLib;
 
 // Ignore IOStream and all the constructors using it.
 %ignore IOStream;
-%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory*, bool, Properties::ReadStyle);
-%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory*, bool);
-%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory*);
+%ignore TagLib::FLAC::File::File(IOStream*, bool, Properties::ReadStyle, ID3v2::FrameFactory *);
+%ignore TagLib::FLAC::File::File(IOStream*, bool, Properties::ReadStyle);
+%ignore TagLib::FLAC::File::File(IOStream*, bool);
+%ignore TagLib::FLAC::File::File(IOStream*);
+%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory *, bool, Properties::ReadStyle);
+%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory *, bool);
+%ignore TagLib::FLAC::File::File(IOStream*, ID3v2::FrameFactory *);
 %ignore TagLib::FLAC::File::isSupported(IOStream *);
 
 %rename(id3v1_tag) TagLib::FLAC::File::ID3v1Tag;

--- a/ext/taglib_flac/taglib_flac_wrap.cxx
+++ b/ext/taglib_flac/taglib_flac_wrap.cxx
@@ -1854,18 +1854,18 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 /* -------- TYPES TABLE (BEGIN) -------- */
 
 #define SWIGTYPE_p_TagLib__AudioProperties swig_types[0]
-#define SWIGTYPE_p_TagLib__ByteVector swig_types[1]
-#define SWIGTYPE_p_TagLib__FLAC__File swig_types[2]
-#define SWIGTYPE_p_TagLib__FLAC__Picture swig_types[3]
-#define SWIGTYPE_p_TagLib__FLAC__Properties swig_types[4]
-#define SWIGTYPE_p_TagLib__File swig_types[5]
-#define SWIGTYPE_p_TagLib__ID3v1__Tag swig_types[6]
-#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[7]
-#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[8]
-#define SWIGTYPE_p_TagLib__ListT_TagLib__FLAC__Picture_t swig_types[9]
-#define SWIGTYPE_p_TagLib__Ogg__XiphComment swig_types[10]
-#define SWIGTYPE_p_TagLib__Tag swig_types[11]
-#define SWIGTYPE_p_char swig_types[12]
+#define SWIGTYPE_p_TagLib__FLAC__File swig_types[1]
+#define SWIGTYPE_p_TagLib__FLAC__Picture swig_types[2]
+#define SWIGTYPE_p_TagLib__FLAC__Properties swig_types[3]
+#define SWIGTYPE_p_TagLib__File swig_types[4]
+#define SWIGTYPE_p_TagLib__ID3v1__Tag swig_types[5]
+#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[6]
+#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[7]
+#define SWIGTYPE_p_TagLib__ListT_TagLib__FLAC__Picture_t swig_types[8]
+#define SWIGTYPE_p_TagLib__Ogg__XiphComment swig_types[9]
+#define SWIGTYPE_p_TagLib__Tag swig_types[10]
+#define SWIGTYPE_p_char swig_types[11]
+#define SWIGTYPE_p_long_long swig_types[12]
 #define SWIGTYPE_p_unsigned_char swig_types[13]
 #define SWIGTYPE_p_unsigned_int swig_types[14]
 #define SWIGTYPE_p_unsigned_long swig_types[15]
@@ -1966,34 +1966,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2082,6 +2074,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 VALUE taglib_flac_picturelist_to_ruby_array(const TagLib::List<TagLib::FLAC::Picture *> & list) {
@@ -2100,6 +2099,53 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 {
   return Qnil;
 } 
+
+
+#include <limits.h>
+#if !defined(SWIG_NO_LLONG_MAX)
+# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
+#   define LLONG_MAX __LONG_LONG_MAX__
+#   define LLONG_MIN (-LLONG_MAX - 1LL)
+#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
+# endif
+#endif
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (VALUE obj, long long *val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
+}
+#endif
 
 
 /*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
@@ -2132,16 +2178,6 @@ SWIG_AsVal_long (VALUE obj, long* val)
 }
 
 
-#include <limits.h>
-#if !defined(SWIG_NO_LLONG_MAX)
-# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
-#   define LLONG_MAX __LONG_LONG_MAX__
-#   define LLONG_MIN (-LLONG_MAX - 1LL)
-#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
-# endif
-#endif
-
-
 SWIGINTERN int
 SWIG_AsVal_int (VALUE obj, int *val)
 {
@@ -2155,50 +2191,6 @@ SWIG_AsVal_int (VALUE obj, int *val)
     }
   }  
   return res;
-}
-
-
-  #define SWIG_From_long   LONG2NUM 
-
-
-SWIGINTERNINLINE VALUE
-SWIG_From_int  (int value)
-{    
-  return SWIG_From_long  (value);
-}
-
-
-#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
-#  define SWIG_LONG_LONG_AVAILABLE
-#endif
-
-
-#ifdef SWIG_LONG_LONG_AVAILABLE
-SWIGINTERNINLINE VALUE 
-SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
-{
-  return ULL2NUM(value);
-}
-#endif
-
-
-SWIGINTERN int
-SWIG_AsVal_bool (VALUE obj, bool *val)
-{
-  if (obj == Qtrue) {
-    if (val) *val = true;
-    return SWIG_OK;
-  } else if (obj == Qfalse) {
-    if (val) *val = false;
-    return SWIG_OK;
-  } else {
-    int res = 0;
-    if (SWIG_AsVal_int (obj, &res) == SWIG_OK) {    
-      if (val) *val = res ? true : false;
-      return SWIG_OK;
-    }
-  }  
-  return SWIG_TypeError;
 }
 
 
@@ -2250,6 +2242,45 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 
 
 
+
+
+  #define SWIG_From_long   LONG2NUM 
+
+
+SWIGINTERNINLINE VALUE
+SWIG_From_int  (int value)
+{    
+  return SWIG_From_long  (value);
+}
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERNINLINE VALUE 
+SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
+{
+  return ULL2NUM(value);
+}
+#endif
+
+
+SWIGINTERN int
+SWIG_AsVal_bool (VALUE obj, bool *val)
+{
+  if (obj == Qtrue) {
+    if (val) *val = true;
+    return SWIG_OK;
+  } else if (obj == Qfalse) {
+    if (val) *val = false;
+    return SWIG_OK;
+  } else {
+    int res = 0;
+    if (SWIG_AsVal_int (obj, &res) == SWIG_OK) {    
+      if (val) *val = res ? true : false;
+      return SWIG_OK;
+    }
+  }  
+  return SWIG_TypeError;
+}
 
 
 SWIGINTERNINLINE VALUE
@@ -2319,12 +2350,11 @@ static swig_class SwigClassProperties;
 
 SWIGINTERN VALUE
 _wrap_new_Properties__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::ByteVector arg1 ;
-  long arg2 ;
+  TagLib::ByteVector *arg1 = 0 ;
+  TagLib::offset_t arg2 ;
   TagLib::AudioProperties::ReadStyle arg3 ;
-  void *argp1 ;
-  int res1 = 0 ;
-  long val2 ;
+  TagLib::ByteVector tmp1 ;
+  long long val2 ;
   int ecode2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -2334,97 +2364,20 @@ _wrap_new_Properties__SWIG_0(int argc, VALUE *argv, VALUE self) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
   }
   {
-    res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__ByteVector,  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ByteVector","Properties", 1, argv[0] )); 
-    }  
-    if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::ByteVector","Properties", 1, argv[0]));
-    } else {
-      arg1 = *(reinterpret_cast< TagLib::ByteVector * >(argp1));
-    }
+    tmp1 = ruby_string_to_taglib_bytevector(argv[0]);
+    arg1 = &tmp1;
   }
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Properties", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Properties", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   ecode3 = SWIG_AsVal_int(argv[2], &val3);
   if (!SWIG_IsOK(ecode3)) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::AudioProperties::ReadStyle","Properties", 3, argv[2] ));
   } 
   arg3 = static_cast< TagLib::AudioProperties::ReadStyle >(val3);
-  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties(arg1,arg2,arg3);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Properties__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::ByteVector arg1 ;
-  long arg2 ;
-  void *argp1 ;
-  int res1 = 0 ;
-  long val2 ;
-  int ecode2 = 0 ;
-  TagLib::FLAC::Properties *result = 0 ;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  {
-    res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__ByteVector,  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ByteVector","Properties", 1, argv[0] )); 
-    }  
-    if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::ByteVector","Properties", 1, argv[0]));
-    } else {
-      arg1 = *(reinterpret_cast< TagLib::ByteVector * >(argp1));
-    }
-  }
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Properties", 2, argv[1] ));
-  } 
-  arg2 = static_cast< long >(val2);
-  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties(arg1,arg2);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Properties__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
-  TagLib::AudioProperties::ReadStyle arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  TagLib::FLAC::Properties *result = 0 ;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__FLAC__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::File *","Properties", 1, argv[0] )); 
-  }
-  arg1 = reinterpret_cast< TagLib::FLAC::File * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::AudioProperties::ReadStyle","Properties", 2, argv[1] ));
-  } 
-  arg2 = static_cast< TagLib::AudioProperties::ReadStyle >(val2);
-  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties(arg1,arg2);
+  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties((TagLib::ByteVector const &)*arg1,arg2,arg3);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
   return self;
@@ -2449,21 +2402,27 @@ _wrap_Properties_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_Properties__SWIG_3(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
+_wrap_new_Properties__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::ByteVector *arg1 = 0 ;
+  TagLib::offset_t arg2 ;
+  TagLib::ByteVector tmp1 ;
+  long long val2 ;
+  int ecode2 = 0 ;
   TagLib::FLAC::Properties *result = 0 ;
   
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__FLAC__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::File *","Properties", 1, argv[0] )); 
+  {
+    tmp1 = ruby_string_to_taglib_bytevector(argv[0]);
+    arg1 = &tmp1;
   }
-  arg1 = reinterpret_cast< TagLib::FLAC::File * >(argp1);
-  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties(arg1);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Properties", 2, argv[1] ));
+  } 
+  arg2 = static_cast< TagLib::offset_t >(val2);
+  result = (TagLib::FLAC::Properties *)new TagLib::FLAC::Properties((TagLib::ByteVector const &)*arg1,arg2);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
   return self;
@@ -2482,38 +2441,13 @@ SWIGINTERN VALUE _wrap_new_Properties(int nargs, VALUE *args, VALUE self) {
   for (ii = 0; (ii < argc); ++ii) {
     argv[ii] = args[ii];
   }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__FLAC__File, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Properties__SWIG_3(nargs, args, self);
-    }
-  }
   if (argc == 2) {
     int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__FLAC__File, 0);
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_int(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_new_Properties__SWIG_2(nargs, args, self);
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ByteVector, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -2523,12 +2457,11 @@ SWIGINTERN VALUE _wrap_new_Properties(int nargs, VALUE *args, VALUE self) {
   }
   if (argc == 3) {
     int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ByteVector, SWIG_POINTER_NO_NULL);
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -2545,10 +2478,8 @@ SWIGINTERN VALUE _wrap_new_Properties(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Properties.new", 
-    "    Properties.new(TagLib::ByteVector data, long streamLength, TagLib::AudioProperties::ReadStyle style)\n"
-    "    Properties.new(TagLib::ByteVector data, long streamLength)\n"
-    "    Properties.new(TagLib::FLAC::File *file, TagLib::AudioProperties::ReadStyle style)\n"
-    "    Properties.new(TagLib::FLAC::File *file)\n");
+    "    Properties.new(TagLib::ByteVector const &data, TagLib::offset_t streamLength, TagLib::AudioProperties::ReadStyle style)\n"
+    "    Properties.new(TagLib::ByteVector const &data, TagLib::offset_t streamLength)\n");
   
   return Qnil;
 }
@@ -2560,30 +2491,6 @@ free_TagLib_FLAC_Properties(void *self) {
     SWIG_RubyRemoveTracking(arg1);
     delete arg1;
 }
-
-SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::Properties *arg1 = (TagLib::FLAC::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__FLAC__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::FLAC::Properties * >(argp1);
-  result = (int)((TagLib::FLAC::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
 
 SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
@@ -2762,6 +2669,53 @@ _wrap_new_File__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   TagLib::FLAC::Properties::ReadStyle arg3 ;
+  TagLib::ID3v2::FrameFactory *arg4 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  TagLib::FLAC::File *result = 0 ;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  {
+    arg1 = ruby_string_to_taglib_filename(argv[0]);
+    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
+      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
+    }
+  }
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","File", 2, argv[1] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::FLAC::Properties::ReadStyle","File", 3, argv[2] ));
+  } 
+  arg3 = static_cast< TagLib::FLAC::Properties::ReadStyle >(val3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory *","File", 4, argv[3] )); 
+  }
+  arg4 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp4);
+  result = (TagLib::FLAC::File *)new TagLib::FLAC::File(arg1,arg2,arg3,arg4);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::FileName arg1 ;
+  bool arg2 ;
+  TagLib::FLAC::Properties::ReadStyle arg3 ;
   bool val2 ;
   int ecode2 = 0 ;
   int val3 ;
@@ -2797,7 +2751,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   bool val2 ;
@@ -2828,7 +2782,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::FLAC::File *result = 0 ;
   
@@ -2851,7 +2805,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_4(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   bool arg3 ;
@@ -2898,7 +2852,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_4(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_5(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   bool arg3 ;
@@ -2952,7 +2906,7 @@ _wrap_File_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_5(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_6(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   void *argp2 = 0 ;
@@ -2997,7 +2951,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_File__SWIG_2(nargs, args, self);
+      return _wrap_new_File__SWIG_3(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -3009,7 +2963,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_new_File__SWIG_5(nargs, args, self);
+        return _wrap_new_File__SWIG_6(nargs, args, self);
       }
     }
   }
@@ -3023,7 +2977,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_File__SWIG_1(nargs, args, self);
+        return _wrap_new_File__SWIG_2(nargs, args, self);
       }
     }
   }
@@ -3041,7 +2995,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_4(nargs, args, self);
+          return _wrap_new_File__SWIG_5(nargs, args, self);
         }
       }
     }
@@ -3061,7 +3015,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_0(nargs, args, self);
+          return _wrap_new_File__SWIG_1(nargs, args, self);
         }
       }
     }
@@ -3085,7 +3039,32 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
             _v = SWIG_CheckState(res);
           }
           if (_v) {
-            return _wrap_new_File__SWIG_3(nargs, args, self);
+            return _wrap_new_File__SWIG_4(nargs, args, self);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_new_File__SWIG_0(nargs, args, self);
           }
         }
       }
@@ -3094,6 +3073,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 4, "File.new", 
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::FLAC::Properties::ReadStyle propertiesStyle, TagLib::ID3v2::FrameFactory *frameFactory)\n"
     "    File.new(TagLib::FileName file, bool readProperties, TagLib::FLAC::Properties::ReadStyle propertiesStyle)\n"
     "    File.new(TagLib::FileName file, bool readProperties)\n"
     "    File.new(TagLib::FileName file)\n"
@@ -3481,85 +3461,6 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_File_set_id3v2_frame_factory(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
-  TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__FLAC__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::File *","setID3v2FrameFactory", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::FLAC::File * >(argp1);
-  res2 = SWIG_ConvertPtr(argv[0], &argp2,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","setID3v2FrameFactory", 2, argv[0] )); 
-  }
-  arg2 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp2);
-  (arg1)->setID3v2FrameFactory((TagLib::ID3v2::FrameFactory const *)arg2);
-  return Qnil;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_stream_info_data(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__FLAC__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::File *","streamInfoData", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::FLAC::File * >(argp1);
-  result = (arg1)->streamInfoData();
-  {
-    vresult = taglib_bytevector_to_ruby_string(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_stream_length(int argc, VALUE *argv, VALUE self) {
-  TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  long result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__FLAC__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::FLAC::File *","streamLength", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::FLAC::File * >(argp1);
-  result = (long)(arg1)->streamLength();
-  vresult = SWIG_From_long(static_cast< long >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_File_picture_list(int argc, VALUE *argv, VALUE self) {
   TagLib::FLAC::File *arg1 = (TagLib::FLAC::File *) 0 ;
   void *argp1 = 0 ;
@@ -3862,7 +3763,6 @@ static void *_p_TagLib__FLAC__FileTo_p_TagLib__File(void *x, int *SWIGUNUSEDPARM
     return (void *)((TagLib::File *)  ((TagLib::FLAC::File *) x));
 }
 static swig_type_info _swigt__p_TagLib__AudioProperties = {"_p_TagLib__AudioProperties", "TagLib::AudioProperties *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__ByteVector = {"_p_TagLib__ByteVector", "TagLib::ByteVector *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__FLAC__File = {"_p_TagLib__FLAC__File", "TagLib::FLAC::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__FLAC__Picture = {"_p_TagLib__FLAC__Picture", "TagLib::FLAC::Picture *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__FLAC__Properties = {"_p_TagLib__FLAC__Properties", "TagLib::FLAC::Properties *", 0, 0, (void*)0, 0};
@@ -3874,6 +3774,7 @@ static swig_type_info _swigt__p_TagLib__ListT_TagLib__FLAC__Picture_t = {"_p_Tag
 static swig_type_info _swigt__p_TagLib__Ogg__XiphComment = {"_p_TagLib__Ogg__XiphComment", "TagLib::Ogg::XiphComment *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -3881,7 +3782,6 @@ static swig_type_info _swigt__p_wchar_t = {"_p_wchar_t", "TagLib::wchar *|wchar_
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__AudioProperties,
-  &_swigt__p_TagLib__ByteVector,
   &_swigt__p_TagLib__FLAC__File,
   &_swigt__p_TagLib__FLAC__Picture,
   &_swigt__p_TagLib__FLAC__Properties,
@@ -3893,6 +3793,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__Ogg__XiphComment,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -3900,7 +3801,6 @@ static swig_type_info *swig_type_initial[] = {
 };
 
 static swig_cast_info _swigc__p_TagLib__AudioProperties[] = {  {&_swigt__p_TagLib__AudioProperties, 0, 0, 0},  {&_swigt__p_TagLib__FLAC__Properties, _p_TagLib__FLAC__PropertiesTo_p_TagLib__AudioProperties, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_TagLib__ByteVector[] = {  {&_swigt__p_TagLib__ByteVector, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__FLAC__File[] = {  {&_swigt__p_TagLib__FLAC__File, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__FLAC__Picture[] = {  {&_swigt__p_TagLib__FLAC__Picture, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__FLAC__Properties[] = {  {&_swigt__p_TagLib__FLAC__Properties, 0, 0, 0},{0, 0, 0, 0}};
@@ -3912,6 +3812,7 @@ static swig_cast_info _swigc__p_TagLib__ListT_TagLib__FLAC__Picture_t[] = {  {&_
 static swig_cast_info _swigc__p_TagLib__Ogg__XiphComment[] = {  {&_swigt__p_TagLib__Ogg__XiphComment, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -3919,7 +3820,6 @@ static swig_cast_info _swigc__p_wchar_t[] = {  {&_swigt__p_wchar_t, 0, 0, 0},{0,
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__AudioProperties,
-  _swigc__p_TagLib__ByteVector,
   _swigc__p_TagLib__FLAC__File,
   _swigc__p_TagLib__FLAC__Picture,
   _swigc__p_TagLib__FLAC__Properties,
@@ -3931,6 +3831,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__Ogg__XiphComment,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -4200,7 +4101,6 @@ SWIGEXPORT void Init_taglib_flac(void) {
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__FLAC__Properties, (void *) &SwigClassProperties);
   rb_define_alloc_func(SwigClassProperties.klass, _wrap_Properties_allocate);
   rb_define_method(SwigClassProperties.klass, "initialize", VALUEFUNC(_wrap_new_Properties), -1);
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);
@@ -4227,9 +4127,6 @@ SWIGEXPORT void Init_taglib_flac(void) {
   rb_define_method(SwigClassFile.klass, "id3v2_tag", VALUEFUNC(_wrap_File_id3v2_tag), -1);
   rb_define_method(SwigClassFile.klass, "id3v1_tag", VALUEFUNC(_wrap_File_id3v1_tag), -1);
   rb_define_method(SwigClassFile.klass, "xiph_comment", VALUEFUNC(_wrap_File_xiph_comment), -1);
-  rb_define_method(SwigClassFile.klass, "set_id3v2_frame_factory", VALUEFUNC(_wrap_File_set_id3v2_frame_factory), -1);
-  rb_define_method(SwigClassFile.klass, "stream_info_data", VALUEFUNC(_wrap_File_stream_info_data), -1);
-  rb_define_method(SwigClassFile.klass, "stream_length", VALUEFUNC(_wrap_File_stream_length), -1);
   rb_define_method(SwigClassFile.klass, "picture_list", VALUEFUNC(_wrap_File_picture_list), -1);
   rb_define_method(SwigClassFile.klass, "remove_picture", VALUEFUNC(_wrap_File_remove_picture), -1);
   rb_define_method(SwigClassFile.klass, "remove_pictures", VALUEFUNC(_wrap_File_remove_pictures), -1);

--- a/ext/taglib_flac_picture/taglib_flac_picture.i
+++ b/ext/taglib_flac_picture/taglib_flac_picture.i
@@ -11,5 +11,6 @@
 %ignore TagLib::FLAC::MetadataBlock::render; // Only useful internally.
 %include <taglib/flacmetadatablock.h>
 
+%include <taglib/tpicturetype.h>
 %ignore TagLib::FLAC::Picture::render; // Only useful internally.
 %include <taglib/flacpicture.h>

--- a/ext/taglib_flac_picture/taglib_flac_picture.i
+++ b/ext/taglib_flac_picture/taglib_flac_picture.i
@@ -11,6 +11,9 @@
 %ignore TagLib::FLAC::MetadataBlock::render; // Only useful internally.
 %include <taglib/flacmetadatablock.h>
 
+%ignore TagLib::Utils::pictureTypeToString;
+%ignore TagLib::Utils::pictureTypeFromString;
 %include <taglib/tpicturetype.h>
+
 %ignore TagLib::FLAC::Picture::render; // Only useful internally.
 %include <taglib/flacpicture.h>

--- a/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
+++ b/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
@@ -2242,54 +2242,6 @@ fail:
 }
 
 
-SWIGINTERN VALUE
-_wrap_picture_type_to_string(int argc, VALUE *argv, VALUE self) {
-  int arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  TagLib::String result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib::Utils::pictureTypeToString", 1, argv[0] ));
-  } 
-  arg1 = static_cast< int >(val1);
-  result = TagLib::Utils::pictureTypeToString(arg1);
-  {
-    vresult = taglib_string_to_ruby_string(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_picture_type_from_string(int argc, VALUE *argv, VALUE self) {
-  TagLib::String *arg1 = 0 ;
-  TagLib::String tmp1 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_string_to_taglib_string(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (int)TagLib::Utils::pictureTypeFromString((TagLib::String const &)*arg1);
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
 static swig_class SwigClassPicture;
 
 SWIGINTERN VALUE
@@ -3231,8 +3183,6 @@ SWIGEXPORT void Init_taglib_flac_picture(void) {
   SwigClassMetadataBlock.mark = 0;
   SwigClassMetadataBlock.destroy = (void (*)(void *)) free_TagLib_FLAC_MetadataBlock;
   SwigClassMetadataBlock.trackObjects = 1;
-  rb_define_module_function(mFLAC, "picture_type_to_string", VALUEFUNC(_wrap_picture_type_to_string), -1);
-  rb_define_module_function(mFLAC, "picture_type_from_string", VALUEFUNC(_wrap_picture_type_from_string), -1);
   
   SwigClassPicture.klass = rb_define_class_under(mFLAC, "Picture", ((swig_class *) SWIGTYPE_p_TagLib__FLAC__MetadataBlock->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__FLAC__Picture, (void *) &SwigClassPicture);

--- a/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
+++ b/ext/taglib_flac_picture/taglib_flac_picture_wrap.cxx
@@ -1854,12 +1854,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__FLAC__Picture swig_types[1]
 #define SWIGTYPE_p_TagLib__ListT_TagLib__FLAC__Picture_t swig_types[2]
 #define SWIGTYPE_p_char swig_types[3]
-#define SWIGTYPE_p_unsigned_char swig_types[4]
-#define SWIGTYPE_p_unsigned_int swig_types[5]
-#define SWIGTYPE_p_unsigned_long swig_types[6]
-#define SWIGTYPE_p_wchar_t swig_types[7]
-static swig_type_info *swig_types[9];
-static swig_module_info swig_module = {swig_types, 8, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[4]
+#define SWIGTYPE_p_unsigned_char swig_types[5]
+#define SWIGTYPE_p_unsigned_int swig_types[6]
+#define SWIGTYPE_p_unsigned_long swig_types[7]
+#define SWIGTYPE_p_wchar_t swig_types[8]
+static swig_type_info *swig_types[10];
+static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1951,34 +1952,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2067,6 +2060,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 VALUE taglib_flac_picturelist_to_ruby_array(const TagLib::List<TagLib::FLAC::Picture *> & list) {
@@ -2098,56 +2098,6 @@ SWIG_From_int  (int value)
 {    
   return SWIG_From_long  (value);
 }
-
-
-SWIGINTERN swig_type_info*
-SWIG_pchar_descriptor(void)
-{
-  static int init = 0;
-  static swig_type_info* info = 0;
-  if (!init) {
-    info = SWIG_TypeQuery("_p_char");
-    init = 1;
-  }
-  return info;
-}
-
-
-SWIGINTERN int
-SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
-{
-  if (TYPE(obj) == T_STRING) {
-    char *cstr = StringValuePtr(obj); 
-    size_t size = RSTRING_LEN(obj) + 1;
-    if (cptr)  {
-      if (alloc) {
-	if (*alloc == SWIG_NEWOBJ) {
-	  *cptr = reinterpret_cast< char* >(memcpy(new char[size], cstr, sizeof(char)*(size)));
-	} else {
-	  *cptr = cstr;
-	  *alloc = SWIG_OLDOBJ;
-	}
-      }
-    }
-    if (psize) *psize = size;
-    return SWIG_OK;
-  } else {
-    swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
-    if (pchar_descriptor) {
-      void* vptr = 0;
-      if (SWIG_ConvertPtr(obj, &vptr, pchar_descriptor, 0) == SWIG_OK) {
-	if (cptr) *cptr = (char *)vptr;
-	if (psize) *psize = vptr ? (strlen((char*)vptr) + 1) : 0;
-	if (alloc) *alloc = SWIG_OLDOBJ;
-	return SWIG_OK;
-      }
-    }
-  }  
-  return SWIG_TypeError;
-}
-
-
-
 
 
 SWIGINTERN VALUE
@@ -2203,6 +2153,56 @@ SWIG_AsVal_int (VALUE obj, int *val)
 }
 
 
+SWIGINTERN swig_type_info*
+SWIG_pchar_descriptor(void)
+{
+  static int init = 0;
+  static swig_type_info* info = 0;
+  if (!init) {
+    info = SWIG_TypeQuery("_p_char");
+    init = 1;
+  }
+  return info;
+}
+
+
+SWIGINTERN int
+SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
+{
+  if (TYPE(obj) == T_STRING) {
+    char *cstr = StringValuePtr(obj); 
+    size_t size = RSTRING_LEN(obj) + 1;
+    if (cptr)  {
+      if (alloc) {
+	if (*alloc == SWIG_NEWOBJ) {
+	  *cptr = reinterpret_cast< char* >(memcpy(new char[size], cstr, sizeof(char)*(size)));
+	} else {
+	  *cptr = cstr;
+	  *alloc = SWIG_OLDOBJ;
+	}
+      }
+    }
+    if (psize) *psize = size;
+    return SWIG_OK;
+  } else {
+    swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
+    if (pchar_descriptor) {
+      void* vptr = 0;
+      if (SWIG_ConvertPtr(obj, &vptr, pchar_descriptor, 0) == SWIG_OK) {
+	if (cptr) *cptr = (char *)vptr;
+	if (psize) *psize = vptr ? (strlen((char*)vptr) + 1) : 0;
+	if (alloc) *alloc = SWIG_OLDOBJ;
+	return SWIG_OK;
+      }
+    }
+  }  
+  return SWIG_TypeError;
+}
+
+
+
+
+
 SWIGINTERNINLINE VALUE
 SWIG_From_bool  (bool value)
 {
@@ -2242,7 +2242,103 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_picture_type_to_string(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib::Utils::pictureTypeToString", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  result = TagLib::Utils::pictureTypeToString(arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_picture_type_from_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (int)TagLib::Utils::pictureTypeFromString((TagLib::String const &)*arg1);
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassPicture;
+
+SWIGINTERN VALUE
+_wrap_Picture_type_to_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::FLAC::Picture::Type arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "TagLib::FLAC::Picture::Type","TagLib::FLAC::Picture::typeToString", 1, argv[0] ));
+  } 
+  arg1 = static_cast< TagLib::FLAC::Picture::Type >(val1);
+  result = TagLib::FLAC::Picture::typeToString(arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Picture_type_from_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  TagLib::FLAC::Picture::Type result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::FLAC::Picture::Type)TagLib::FLAC::Picture::typeFromString((TagLib::String const &)*arg1);
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
 
 SWIGINTERN VALUE
 _wrap_new_Picture__SWIG_0(int argc, VALUE *argv, VALUE self) {
@@ -2823,6 +2919,7 @@ static swig_type_info _swigt__p_TagLib__FLAC__MetadataBlock = {"_p_TagLib__FLAC_
 static swig_type_info _swigt__p_TagLib__FLAC__Picture = {"_p_TagLib__FLAC__Picture", "TagLib::FLAC::Picture *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ListT_TagLib__FLAC__Picture_t = {"_p_TagLib__ListT_TagLib__FLAC__Picture_t", "TagLib::FLAC::PictureList *|TagLib::List< TagLib::FLAC::Picture > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -2833,6 +2930,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__FLAC__Picture,
   &_swigt__p_TagLib__ListT_TagLib__FLAC__Picture_t,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -2843,6 +2941,7 @@ static swig_cast_info _swigc__p_TagLib__FLAC__MetadataBlock[] = {  {&_swigt__p_T
 static swig_cast_info _swigc__p_TagLib__FLAC__Picture[] = {  {&_swigt__p_TagLib__FLAC__Picture, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ListT_TagLib__FLAC__Picture_t[] = {  {&_swigt__p_TagLib__ListT_TagLib__FLAC__Picture_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -2853,6 +2952,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__FLAC__Picture,
   _swigc__p_TagLib__ListT_TagLib__FLAC__Picture_t,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -3131,6 +3231,8 @@ SWIGEXPORT void Init_taglib_flac_picture(void) {
   SwigClassMetadataBlock.mark = 0;
   SwigClassMetadataBlock.destroy = (void (*)(void *)) free_TagLib_FLAC_MetadataBlock;
   SwigClassMetadataBlock.trackObjects = 1;
+  rb_define_module_function(mFLAC, "picture_type_to_string", VALUEFUNC(_wrap_picture_type_to_string), -1);
+  rb_define_module_function(mFLAC, "picture_type_from_string", VALUEFUNC(_wrap_picture_type_from_string), -1);
   
   SwigClassPicture.klass = rb_define_class_under(mFLAC, "Picture", ((swig_class *) SWIGTYPE_p_TagLib__FLAC__MetadataBlock->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__FLAC__Picture, (void *) &SwigClassPicture);
@@ -3157,6 +3259,8 @@ SWIGEXPORT void Init_taglib_flac_picture(void) {
   rb_define_const(SwigClassPicture.klass, "Illustration", SWIG_From_int(static_cast< int >(TagLib::FLAC::Picture::Illustration)));
   rb_define_const(SwigClassPicture.klass, "BandLogo", SWIG_From_int(static_cast< int >(TagLib::FLAC::Picture::BandLogo)));
   rb_define_const(SwigClassPicture.klass, "PublisherLogo", SWIG_From_int(static_cast< int >(TagLib::FLAC::Picture::PublisherLogo)));
+  rb_define_singleton_method(SwigClassPicture.klass, "type_to_string", VALUEFUNC(_wrap_Picture_type_to_string), -1);
+  rb_define_singleton_method(SwigClassPicture.klass, "type_from_string", VALUEFUNC(_wrap_Picture_type_from_string), -1);
   rb_define_method(SwigClassPicture.klass, "type", VALUEFUNC(_wrap_Picture_type), -1);
   rb_define_method(SwigClassPicture.klass, "type=", VALUEFUNC(_wrap_Picture_typee___), -1);
   rb_define_method(SwigClassPicture.klass, "mime_type", VALUEFUNC(_wrap_Picture_mime_type), -1);

--- a/ext/taglib_id3v1/taglib_id3v1.i
+++ b/ext/taglib_id3v1/taglib_id3v1.i
@@ -2,8 +2,6 @@
 %{
 #include <taglib/id3v1tag.h>
 #include <taglib/id3v1genres.h>
-#include <taglib/tpicturetype.h>
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_id3v1/taglib_id3v1.i
+++ b/ext/taglib_id3v1/taglib_id3v1.i
@@ -2,6 +2,8 @@
 %{
 #include <taglib/id3v1tag.h>
 #include <taglib/id3v1genres.h>
+#include <taglib/tpicturetype.h>
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
+++ b/ext/taglib_id3v1/taglib_id3v1_wrap.cxx
@@ -1856,12 +1856,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__ID3v1__Tag swig_types[3]
 #define SWIGTYPE_p_TagLib__Tag swig_types[4]
 #define SWIGTYPE_p_char swig_types[5]
-#define SWIGTYPE_p_unsigned_char swig_types[6]
-#define SWIGTYPE_p_unsigned_int swig_types[7]
-#define SWIGTYPE_p_unsigned_long swig_types[8]
-#define SWIGTYPE_p_wchar_t swig_types[9]
-static swig_type_info *swig_types[11];
-static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[6]
+#define SWIGTYPE_p_unsigned_char swig_types[7]
+#define SWIGTYPE_p_unsigned_int swig_types[8]
+#define SWIGTYPE_p_unsigned_long swig_types[9]
+#define SWIGTYPE_p_wchar_t swig_types[10]
+static swig_type_info *swig_types[12];
+static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1953,34 +1954,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2069,6 +2062,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 SWIGINTERN swig_type_info*
@@ -2128,36 +2128,6 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 } 
 
 
-/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
-SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
-{
-  VALUE *args = (VALUE *)arg;
-  VALUE obj = args[0];
-  VALUE type = TYPE(obj);
-  long *res = (long *)(args[1]);
-  *res = type == T_FIXNUM ? NUM2LONG(obj) : rb_big2long(obj);
-  return obj;
-}
-/*@SWIG@*/
-
-SWIGINTERN int
-SWIG_AsVal_long (VALUE obj, long* val)
-{
-  VALUE type = TYPE(obj);
-  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
-    long v;
-    VALUE a[2];
-    a[0] = obj;
-    a[1] = (VALUE)(&v);
-    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LONG), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
-      if (val) *val = v;
-      return SWIG_OK;
-    }
-  }
-  return SWIG_TypeError;
-}
-
-
 #include <limits.h>
 #if !defined(SWIG_NO_LLONG_MAX)
 # if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
@@ -2165,6 +2135,43 @@ SWIG_AsVal_long (VALUE obj, long* val)
 #   define LLONG_MIN (-LLONG_MAX - 1LL)
 #   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
 # endif
+#endif
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (VALUE obj, long long *val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
+}
 #endif
 
 
@@ -2228,6 +2235,36 @@ SWIG_AsVal_unsigned_SS_int (VALUE obj, unsigned int *val)
     }
   }  
   return res;
+}
+
+
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long *res = (long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LONG(obj) : rb_big2long(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long (VALUE obj, long* val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LONG), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
 }
 
 
@@ -2297,6 +2334,13 @@ fail:
 }
 
 
+SWIGINTERN void
+free_TagLib_ID3v1_StringHandler(void *self) {
+    TagLib::ID3v1::StringHandler *arg1 = (TagLib::ID3v1::StringHandler *)self;
+    SWIG_RubyRemoveTracking(arg1);
+    delete arg1;
+}
+
 SWIGINTERN VALUE
 _wrap_StringHandler_parse(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v1::StringHandler *arg1 = (TagLib::ID3v1::StringHandler *) 0 ;
@@ -2361,13 +2405,6 @@ fail:
 }
 
 
-SWIGINTERN void
-free_TagLib_ID3v1_StringHandler(void *self) {
-    TagLib::ID3v1::StringHandler *arg1 = (TagLib::ID3v1::StringHandler *)self;
-    SWIG_RubyRemoveTracking(arg1);
-    delete arg1;
-}
-
 static swig_class SwigClassTag;
 
 SWIGINTERN VALUE
@@ -2404,10 +2441,10 @@ _wrap_Tag_allocate(int argc, VALUE *argv, VALUE self)
 SWIGINTERN VALUE
 _wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   TagLib::ID3v1::Tag *result = 0 ;
   
@@ -2419,11 +2456,11 @@ _wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Tag", 1, argv[0] )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Tag", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Tag", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   result = (TagLib::ID3v1::Tag *)new TagLib::ID3v1::Tag(arg1,arg2);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
@@ -2453,7 +2490,7 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -2465,7 +2502,7 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 2, "Tag.new", 
     "    Tag.new()\n"
-    "    Tag.new(TagLib::File *file, long tagOffset)\n");
+    "    Tag.new(TagLib::File *file, TagLib::offset_t tagOffset)\n");
   
   return Qnil;
 }
@@ -3063,6 +3100,7 @@ static swig_type_info _swigt__p_TagLib__ID3v1__StringHandler = {"_p_TagLib__ID3v
 static swig_type_info _swigt__p_TagLib__ID3v1__Tag = {"_p_TagLib__ID3v1__Tag", "TagLib::ID3v1::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -3075,6 +3113,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__ID3v1__Tag,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -3087,6 +3126,7 @@ static swig_cast_info _swigc__p_TagLib__ID3v1__StringHandler[] = {  {&_swigt__p_
 static swig_cast_info _swigc__p_TagLib__ID3v1__Tag[] = {  {&_swigt__p_TagLib__ID3v1__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},  {&_swigt__p_TagLib__ID3v1__Tag, _p_TagLib__ID3v1__TagTo_p_TagLib__Tag, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -3099,6 +3139,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__ID3v1__Tag,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,

--- a/ext/taglib_id3v2/taglib_id3v2.i
+++ b/ext/taglib_id3v2/taglib_id3v2.i
@@ -20,6 +20,7 @@
 #include <taglib/unknownframe.h>
 #include <taglib/unsynchronizedlyricsframe.h>
 #include <taglib/urllinkframe.h>
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -81,6 +82,7 @@ VALUE taglib_id3v2_framelist_to_ruby_array(TagLib::ID3v2::FrameList *list) {
 }
 %}
 
+%include <taglib/id3v2.h>
 %include <taglib/id3v2header.h>
 
 // Only useful internally.

--- a/ext/taglib_id3v2/taglib_id3v2.i
+++ b/ext/taglib_id3v2/taglib_id3v2.i
@@ -132,7 +132,10 @@ VALUE taglib_id3v2_framelist_to_ruby_array(TagLib::ID3v2::FrameList *list) {
 
 %include "relativevolumeframe.i"
 
+%ignore TagLib::Utils::pictureTypeToString;
+%ignore TagLib::Utils::pictureTypeFromString;
 %include <taglib/tpicturetype.h>
+
 %include <taglib/attachedpictureframe.h>
 
 // Ignore the unified property interface.

--- a/ext/taglib_id3v2/taglib_id3v2.i
+++ b/ext/taglib_id3v2/taglib_id3v2.i
@@ -20,7 +20,6 @@
 #include <taglib/unknownframe.h>
 #include <taglib/unsynchronizedlyricsframe.h>
 #include <taglib/urllinkframe.h>
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -133,6 +132,7 @@ VALUE taglib_id3v2_framelist_to_ruby_array(TagLib::ID3v2::FrameList *list) {
 
 %include "relativevolumeframe.i"
 
+%include <taglib/tpicturetype.h>
 %include <taglib/attachedpictureframe.h>
 
 // Ignore the unified property interface.

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -1859,9 +1859,9 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__ID3v2__ChapterFrame swig_types[6]
 #define SWIGTYPE_p_TagLib__ID3v2__CommentsFrame swig_types[7]
 #define SWIGTYPE_p_TagLib__ID3v2__ExtendedHeader swig_types[8]
-#define SWIGTYPE_p_TagLib__ID3v2__Footer swig_types[9]
-#define SWIGTYPE_p_TagLib__ID3v2__Frame swig_types[10]
-#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[11]
+#define SWIGTYPE_p_TagLib__ID3v2__Frame swig_types[9]
+#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[10]
+#define SWIGTYPE_p_TagLib__ID3v2__Frame__Header swig_types[11]
 #define SWIGTYPE_p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame swig_types[12]
 #define SWIGTYPE_p_TagLib__ID3v2__Header swig_types[13]
 #define SWIGTYPE_p_TagLib__ID3v2__PopularimeterFrame swig_types[14]
@@ -1880,12 +1880,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__ListT_TagLib__ID3v2__Frame_p_t swig_types[27]
 #define SWIGTYPE_p_TagLib__Tag swig_types[28]
 #define SWIGTYPE_p_char swig_types[29]
-#define SWIGTYPE_p_unsigned_char swig_types[30]
-#define SWIGTYPE_p_unsigned_int swig_types[31]
-#define SWIGTYPE_p_unsigned_long swig_types[32]
-#define SWIGTYPE_p_wchar_t swig_types[33]
-static swig_type_info *swig_types[35];
-static swig_module_info swig_module = {swig_types, 34, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[30]
+#define SWIGTYPE_p_unsigned_char swig_types[31]
+#define SWIGTYPE_p_unsigned_int swig_types[32]
+#define SWIGTYPE_p_unsigned_long swig_types[33]
+#define SWIGTYPE_p_wchar_t swig_types[34]
+static swig_type_info *swig_types[36];
+static swig_module_info swig_module = {swig_types, 35, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1995,34 +1996,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2111,6 +2104,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 VALUE taglib_id3v2_frame_to_ruby_object(const TagLib::ID3v2::Frame *frame) {
@@ -2162,6 +2162,26 @@ VALUE taglib_id3v2_framelist_to_ruby_array(TagLib::ID3v2::FrameList *list) {
 }
 
 
+#include <limits.h>
+#if !defined(SWIG_NO_LLONG_MAX)
+# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
+#   define LLONG_MAX __LONG_LONG_MAX__
+#   define LLONG_MIN (-LLONG_MAX - 1LL)
+#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
+# endif
+#endif
+
+
+  #define SWIG_From_long   LONG2NUM 
+
+
+SWIGINTERNINLINE VALUE
+SWIG_From_int  (int value)
+{    
+  return SWIG_From_long  (value);
+}
+
+
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -2210,19 +2230,6 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 
 
 
-
-
-#include <limits.h>
-#if !defined(SWIG_NO_LLONG_MAX)
-# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
-#   define LLONG_MAX __LONG_LONG_MAX__
-#   define LLONG_MIN (-LLONG_MAX - 1LL)
-#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
-# endif
-#endif
-
-
-  #define SWIG_From_long   LONG2NUM 
 
 
 SWIGINTERNINLINE VALUE
@@ -2345,31 +2352,41 @@ SWIG_AsVal_int (VALUE obj, int *val)
 }
 
 
-SWIGINTERN int
-SWIG_AsVal_bool (VALUE obj, bool *val)
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
 {
-  if (obj == Qtrue) {
-    if (val) *val = true;
-    return SWIG_OK;
-  } else if (obj == Qfalse) {
-    if (val) *val = false;
-    return SWIG_OK;
-  } else {
-    int res = 0;
-    if (SWIG_AsVal_int (obj, &res) == SWIG_OK) {    
-      if (val) *val = res ? true : false;
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (VALUE obj, long long *val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
       return SWIG_OK;
     }
-  }  
+  }
   return SWIG_TypeError;
 }
-
-
-SWIGINTERNINLINE VALUE
-SWIG_From_int  (int value)
-{    
-  return SWIG_From_long  (value);
-}
+#endif
 
 
 SWIGINTERNINLINE VALUE
@@ -2517,6 +2534,26 @@ SWIGINTERNINLINE VALUE
 SWIG_From_unsigned_SS_char  (unsigned char value)
 {    
   return SWIG_From_unsigned_SS_long  (value);
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_bool (VALUE obj, bool *val)
+{
+  if (obj == Qtrue) {
+    if (val) *val = true;
+    return SWIG_OK;
+  } else if (obj == Qfalse) {
+    if (val) *val = false;
+    return SWIG_OK;
+  } else {
+    int res = 0;
+    if (SWIG_AsVal_int (obj, &res) == SWIG_OK) {    
+      if (val) *val = res ? true : false;
+      return SWIG_OK;
+    }
+  }  
+  return SWIG_TypeError;
 }
 
 static swig_class SwigClassHeader;
@@ -3105,6 +3142,32 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_Frame_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::Frame *arg1 = (TagLib::ID3v2::Frame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::Frame const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::Frame * >(argp1);
+  result = ((TagLib::ID3v2::Frame const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_Frame_render(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::Frame *arg1 = (TagLib::ID3v2::Frame *) 0 ;
   void *argp1 = 0 ;
@@ -3124,6 +3187,30 @@ _wrap_Frame_render(int argc, VALUE *argv, VALUE self) {
   {
     vresult = taglib_bytevector_to_ruby_string(result);
   }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Frame_header(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::Frame *arg1 = (TagLib::ID3v2::Frame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::ID3v2::Frame::Header *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::Frame const *","header", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::Frame * >(argp1);
+  result = (TagLib::ID3v2::Frame::Header *)((TagLib::ID3v2::Frame const *)arg1)->header();
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame__Header, 0 |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -3156,6 +3243,54 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_Frame_key_to_frame_id(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  TagLib::ByteVector result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = TagLib::ID3v2::Frame::keyToFrameID((TagLib::String const &)*arg1);
+  {
+    vresult = taglib_bytevector_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Frame_frame_idto_key(int argc, VALUE *argv, VALUE self) {
+  TagLib::ByteVector *arg1 = 0 ;
+  TagLib::ByteVector tmp1 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_bytevector(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = TagLib::ID3v2::Frame::frameIDToKey((TagLib::ByteVector const &)*arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassTag;
 
 SWIGINTERN VALUE
@@ -3177,11 +3312,11 @@ fail:
 SWIGINTERN VALUE
 _wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   TagLib::ID3v2::FrameFactory *arg3 = (TagLib::ID3v2::FrameFactory *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -3195,11 +3330,11 @@ _wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Tag", 1, argv[0] )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Tag", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Tag", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   res3 = SWIG_ConvertPtr(argv[2], &argp3,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
     SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","Tag", 3, argv[2] )); 
@@ -3232,10 +3367,10 @@ _wrap_Tag_allocate(int argc, VALUE *argv, VALUE self)
 SWIGINTERN VALUE
 _wrap_new_Tag__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   TagLib::ID3v2::Tag *result = 0 ;
   
@@ -3247,11 +3382,11 @@ _wrap_new_Tag__SWIG_2(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Tag", 1, argv[0] )); 
   }
   arg1 = reinterpret_cast< TagLib::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Tag", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Tag", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   result = (TagLib::ID3v2::Tag *)new TagLib::ID3v2::Tag(arg1,arg2);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
@@ -3281,7 +3416,7 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -3296,7 +3431,7 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -3313,8 +3448,8 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Tag.new", 
     "    Tag.new()\n"
-    "    Tag.new(TagLib::File *file, long tagOffset, TagLib::ID3v2::FrameFactory const *factory)\n"
-    "    Tag.new(TagLib::File *file, long tagOffset)\n");
+    "    Tag.new(TagLib::File *file, TagLib::offset_t tagOffset, TagLib::ID3v2::FrameFactory const *factory)\n"
+    "    Tag.new(TagLib::File *file, TagLib::offset_t tagOffset)\n");
   
   return Qnil;
 }
@@ -3771,30 +3906,6 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_Tag_footer(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::Tag *arg1 = (TagLib::ID3v2::Tag *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ID3v2::Footer *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__Tag, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::Tag const *","footer", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::Tag * >(argp1);
-  result = (TagLib::ID3v2::Footer *)((TagLib::ID3v2::Tag const *)arg1)->footer();
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Footer, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_Tag_frame_list_map(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::Tag *arg1 = (TagLib::ID3v2::Tag *) 0 ;
   void *argp1 = 0 ;
@@ -4023,113 +4134,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_FrameFactory_create_frame__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
-  TagLib::ByteVector *arg2 = 0 ;
-  bool arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector tmp2 ;
-  bool val3 ;
-  int ecode3 = 0 ;
-  TagLib::ID3v2::Frame *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","createFrame", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
-    arg2 = &tmp2;
-  }
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","createFrame", 3, argv[1] ));
-  } 
-  arg3 = static_cast< bool >(val3);
-  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrame((TagLib::ByteVector const &)*arg2,arg3);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_FrameFactory_create_frame__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
-  TagLib::ByteVector *arg2 = 0 ;
-  unsigned int arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector tmp2 ;
-  unsigned int val3 ;
-  int ecode3 = 0 ;
-  TagLib::ID3v2::Frame *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","createFrame", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
-    arg2 = &tmp2;
-  }
-  ecode3 = SWIG_AsVal_unsigned_SS_int(argv[1], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "unsigned int","createFrame", 3, argv[1] ));
-  } 
-  arg3 = static_cast< unsigned int >(val3);
-  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrame((TagLib::ByteVector const &)*arg2,arg3);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_FrameFactory_create_frame__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
-  TagLib::ByteVector *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector tmp2 ;
-  TagLib::ID3v2::Frame *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","createFrame", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_bytevector(argv[0]);
-    arg2 = &tmp2;
-  }
-  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrame((TagLib::ByteVector const &)*arg2);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_FrameFactory_create_frame__SWIG_3(int argc, VALUE *argv, VALUE self) {
+_wrap_FrameFactory_create_frame(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
   TagLib::ByteVector *arg2 = 0 ;
   TagLib::ID3v2::Header *arg3 = (TagLib::ID3v2::Header *) 0 ;
@@ -4155,10 +4160,10 @@ _wrap_FrameFactory_create_frame__SWIG_3(int argc, VALUE *argv, VALUE self) {
   }
   res3 = SWIG_ConvertPtr(argv[1], &argp3,SWIGTYPE_p_TagLib__ID3v2__Header, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::ID3v2::Header *","createFrame", 3, argv[1] )); 
+    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::ID3v2::Header const *","createFrame", 3, argv[1] )); 
   }
   arg3 = reinterpret_cast< TagLib::ID3v2::Header * >(argp3);
-  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrame((TagLib::ByteVector const &)*arg2,arg3);
+  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrame((TagLib::ByteVector const &)*arg2,(TagLib::ID3v2::Header const *)arg3);
   vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
   return vresult;
 fail:
@@ -4166,94 +4171,38 @@ fail:
 }
 
 
-SWIGINTERN VALUE _wrap_FrameFactory_create_frame(int nargs, VALUE *args, VALUE self) {
-  int argc;
-  VALUE argv[4];
-  int ii;
+SWIGINTERN VALUE
+_wrap_FrameFactory_create_frame_for_property(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  TagLib::StringList *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  TagLib::StringList tmp3 ;
+  TagLib::ID3v2::Frame *result = 0 ;
+  VALUE vresult = Qnil;
   
-  argc = nargs + 1;
-  argv[0] = self;
-  if (argc > 4) SWIG_fail;
-  for (ii = 1; (ii < argc); ++ii) {
-    argv[ii] = args[ii-1];
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
-  if (argc == 2) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_FrameFactory_create_frame__SWIG_2(nargs, args, self);
-      }
-    }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","createFrameForProperty", 1, self )); 
   }
-  if (argc == 3) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_TagLib__ID3v2__Header, 0);
-        _v = SWIG_CheckState(res);
-        if (_v) {
-          return _wrap_FrameFactory_create_frame__SWIG_3(nargs, args, self);
-        }
-      }
-    }
+  arg1 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
   }
-  if (argc == 3) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        {
-          int res = SWIG_AsVal_unsigned_SS_int(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_FrameFactory_create_frame__SWIG_1(nargs, args, self);
-        }
-      }
-    }
+  {
+    tmp3 = ruby_array_to_taglib_string_list(argv[1]);
+    arg3 = &tmp3;
   }
-  if (argc == 3) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_FrameFactory_create_frame__SWIG_0(nargs, args, self);
-        }
-      }
-    }
-  }
-  
+  result = (TagLib::ID3v2::Frame *)((TagLib::ID3v2::FrameFactory const *)arg1)->createFrameForProperty((TagLib::String const &)*arg2,(TagLib::StringList const &)*arg3);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Frame, 0 |  0 );
+  return vresult;
 fail:
-  Ruby_Format_OverloadedError( argc, 4, "FrameFactory.create_frame", 
-    "    TagLib::ID3v2::Frame FrameFactory.create_frame(TagLib::ByteVector const &data, bool synchSafeInts)\n"
-    "    TagLib::ID3v2::Frame FrameFactory.create_frame(TagLib::ByteVector const &data, unsigned int version)\n"
-    "    TagLib::ID3v2::Frame FrameFactory.create_frame(TagLib::ByteVector const &data)\n"
-    "    TagLib::ID3v2::Frame * FrameFactory.create_frame(TagLib::ByteVector const &data, TagLib::ID3v2::Header *tagHeader)\n");
-  
   return Qnil;
 }
 
@@ -4306,6 +4255,30 @@ _wrap_FrameFactory_default_text_encodinge___(int argc, VALUE *argv, VALUE self) 
   arg2 = static_cast< TagLib::String::Type >(val2);
   (arg1)->setDefaultTextEncoding(arg2);
   return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_FrameFactory_is_using_default_text_encoding(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::FrameFactory *arg1 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","isUsingDefaultTextEncoding", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp1);
+  result = (bool)((TagLib::ID3v2::FrameFactory const *)arg1)->isUsingDefaultTextEncoding();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
 fail:
   return Qnil;
 }
@@ -4457,59 +4430,6 @@ _wrap_RelativeVolumeFrame_channels(int argc, VALUE *argv, VALUE self) {
     vresult = ary;
   }
   return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_RelativeVolumeFrame_channel_type(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::RelativeVolumeFrame *arg1 = (TagLib::ID3v2::RelativeVolumeFrame *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ID3v2::RelativeVolumeFrame::ChannelType result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__RelativeVolumeFrame, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::RelativeVolumeFrame const *","channelType", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::RelativeVolumeFrame * >(argp1);
-  result = (TagLib::ID3v2::RelativeVolumeFrame::ChannelType)((TagLib::ID3v2::RelativeVolumeFrame const *)arg1)->channelType();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_RelativeVolumeFrame_channel_typee___(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::RelativeVolumeFrame *arg1 = (TagLib::ID3v2::RelativeVolumeFrame *) 0 ;
-  TagLib::ID3v2::RelativeVolumeFrame::ChannelType arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__RelativeVolumeFrame, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::RelativeVolumeFrame *","setChannelType", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::RelativeVolumeFrame * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::ID3v2::RelativeVolumeFrame::ChannelType","setChannelType", 2, argv[0] ));
-  } 
-  arg2 = static_cast< TagLib::ID3v2::RelativeVolumeFrame::ChannelType >(val2);
-  (arg1)->setChannelType(arg2);
-  return Qnil;
 fail:
   return Qnil;
 }
@@ -5247,37 +5167,6 @@ fail:
 static swig_class SwigClassPeakVolume;
 
 SWIGINTERN VALUE
-#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
-_wrap_PeakVolume_allocate(VALUE self)
-#else
-_wrap_PeakVolume_allocate(int argc, VALUE *argv, VALUE self)
-#endif
-{
-  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__ID3v2__RelativeVolumeFrame__PeakVolume);
-#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
-  rb_obj_call_init(vresult, argc, argv);
-#endif
-  return vresult;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_PeakVolume(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *result = 0 ;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  result = (TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *)new TagLib::ID3v2::RelativeVolumeFrame::PeakVolume();
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_PeakVolume_bits_representing_peak_set(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *arg1 = (TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *) 0 ;
   unsigned char arg2 ;
@@ -5383,6 +5272,37 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
+_wrap_PeakVolume_allocate(VALUE self)
+#else
+_wrap_PeakVolume_allocate(int argc, VALUE *argv, VALUE self)
+#endif
+{
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__ID3v2__RelativeVolumeFrame__PeakVolume);
+#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
+  rb_obj_call_init(vresult, argc, argv);
+#endif
+  return vresult;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_PeakVolume(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *result = 0 ;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  result = (TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *)new TagLib::ID3v2::RelativeVolumeFrame::PeakVolume();
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
 SWIGINTERN void
 free_TagLib_ID3v2_RelativeVolumeFrame_PeakVolume(void *self) {
     TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *arg1 = (TagLib::ID3v2::RelativeVolumeFrame::PeakVolume *)self;
@@ -5390,7 +5310,103 @@ free_TagLib_ID3v2_RelativeVolumeFrame_PeakVolume(void *self) {
     delete arg1;
 }
 
+SWIGINTERN VALUE
+_wrap_picture_type_to_string(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib::Utils::pictureTypeToString", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  result = TagLib::Utils::pictureTypeToString(arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_picture_type_from_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (int)TagLib::Utils::pictureTypeFromString((TagLib::String const &)*arg1);
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassAttachedPictureFrame;
+
+SWIGINTERN VALUE
+_wrap_AttachedPictureFrame_type_to_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::AttachedPictureFrame::Type arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "TagLib::ID3v2::AttachedPictureFrame::Type","TagLib::ID3v2::AttachedPictureFrame::typeToString", 1, argv[0] ));
+  } 
+  arg1 = static_cast< TagLib::ID3v2::AttachedPictureFrame::Type >(val1);
+  result = TagLib::ID3v2::AttachedPictureFrame::typeToString(arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_AttachedPictureFrame_type_from_string(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  TagLib::ID3v2::AttachedPictureFrame::Type result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::ID3v2::AttachedPictureFrame::Type)TagLib::ID3v2::AttachedPictureFrame::typeFromString((TagLib::String const &)*arg1);
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
 
 SWIGINTERN VALUE
 _wrap_new_AttachedPictureFrame__SWIG_0(int argc, VALUE *argv, VALUE self) {
@@ -5502,6 +5518,32 @@ _wrap_AttachedPictureFrame_to_string(int argc, VALUE *argv, VALUE self) {
   result = ((TagLib::ID3v2::AttachedPictureFrame const *)arg1)->toString();
   {
     vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_AttachedPictureFrame_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::AttachedPictureFrame *arg1 = (TagLib::ID3v2::AttachedPictureFrame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__AttachedPictureFrame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::AttachedPictureFrame const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::AttachedPictureFrame * >(argp1);
+  result = ((TagLib::ID3v2::AttachedPictureFrame const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
   }
   return vresult;
 fail:
@@ -7206,6 +7248,32 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_GeneralEncapsulatedObjectFrame_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::GeneralEncapsulatedObjectFrame *arg1 = (TagLib::ID3v2::GeneralEncapsulatedObjectFrame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::GeneralEncapsulatedObjectFrame const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::GeneralEncapsulatedObjectFrame * >(argp1);
+  result = ((TagLib::ID3v2::GeneralEncapsulatedObjectFrame const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_GeneralEncapsulatedObjectFrame_text_encoding(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::GeneralEncapsulatedObjectFrame *arg1 = (TagLib::ID3v2::GeneralEncapsulatedObjectFrame *) 0 ;
   void *argp1 = 0 ;
@@ -7582,6 +7650,32 @@ _wrap_PopularimeterFrame_to_string(int argc, VALUE *argv, VALUE self) {
   result = ((TagLib::ID3v2::PopularimeterFrame const *)arg1)->toString();
   {
     vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_PopularimeterFrame_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::PopularimeterFrame *arg1 = (TagLib::ID3v2::PopularimeterFrame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__PopularimeterFrame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::PopularimeterFrame const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::PopularimeterFrame * >(argp1);
+  result = ((TagLib::ID3v2::PopularimeterFrame const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
   }
   return vresult;
 fail:
@@ -9038,6 +9132,32 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_TextIdentificationFrame_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ID3v2::TextIdentificationFrame *arg1 = (TagLib::ID3v2::TextIdentificationFrame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__TextIdentificationFrame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::TextIdentificationFrame const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::ID3v2::TextIdentificationFrame * >(argp1);
+  result = ((TagLib::ID3v2::TextIdentificationFrame const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_TextIdentificationFrame_text_encoding(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::TextIdentificationFrame *arg1 = (TagLib::ID3v2::TextIdentificationFrame *) 0 ;
   void *argp1 = 0 ;
@@ -9335,6 +9455,13 @@ fail:
 }
 
 
+SWIGINTERN void
+free_TagLib_ID3v2_UserTextIdentificationFrame(void *self) {
+    TagLib::ID3v2::UserTextIdentificationFrame *arg1 = (TagLib::ID3v2::UserTextIdentificationFrame *)self;
+    SWIG_RubyRemoveTracking(arg1);
+    delete arg1;
+}
+
 SWIGINTERN VALUE
 _wrap_UserTextIdentificationFrame_to_string(int argc, VALUE *argv, VALUE self) {
   TagLib::ID3v2::UserTextIdentificationFrame *arg1 = (TagLib::ID3v2::UserTextIdentificationFrame *) 0 ;
@@ -9409,32 +9536,6 @@ _wrap_UserTextIdentificationFrame_descriptione___(int argc, VALUE *argv, VALUE s
   }
   (arg1)->setDescription((TagLib::String const &)*arg2);
   return Qnil;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_UserTextIdentificationFrame_field_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::ID3v2::UserTextIdentificationFrame *arg1 = (TagLib::ID3v2::UserTextIdentificationFrame *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::StringList result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__ID3v2__UserTextIdentificationFrame, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::UserTextIdentificationFrame const *","fieldList", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::ID3v2::UserTextIdentificationFrame * >(argp1);
-  result = ((TagLib::ID3v2::UserTextIdentificationFrame const *)arg1)->fieldList();
-  {
-    vresult = taglib_string_list_to_ruby_array(result);
-  }
-  return vresult;
 fail:
   return Qnil;
 }
@@ -9517,14 +9618,14 @@ _wrap_UserTextIdentificationFrame_find(int argc, VALUE *argv, VALUE self) {
   }
   res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__ID3v2__Tag, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::Tag *","TagLib::ID3v2::UserTextIdentificationFrame::find", 1, argv[0] )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::ID3v2::Tag const *","TagLib::ID3v2::UserTextIdentificationFrame::find", 1, argv[0] )); 
   }
   arg1 = reinterpret_cast< TagLib::ID3v2::Tag * >(argp1);
   {
     tmp2 = ruby_string_to_taglib_string(argv[1]);
     arg2 = &tmp2;
   }
-  result = (TagLib::ID3v2::UserTextIdentificationFrame *)TagLib::ID3v2::UserTextIdentificationFrame::find(arg1,(TagLib::String const &)*arg2);
+  result = (TagLib::ID3v2::UserTextIdentificationFrame *)TagLib::ID3v2::UserTextIdentificationFrame::find((TagLib::ID3v2::Tag const *)arg1,(TagLib::String const &)*arg2);
   vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__UserTextIdentificationFrame, 0 |  0 );
   return vresult;
 fail:
@@ -9532,12 +9633,53 @@ fail:
 }
 
 
-SWIGINTERN void
-free_TagLib_ID3v2_UserTextIdentificationFrame(void *self) {
-    TagLib::ID3v2::UserTextIdentificationFrame *arg1 = (TagLib::ID3v2::UserTextIdentificationFrame *)self;
-    SWIG_RubyRemoveTracking(arg1);
-    delete arg1;
+SWIGINTERN VALUE
+_wrap_UserTextIdentificationFrame_key_to_txxx(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = TagLib::ID3v2::UserTextIdentificationFrame::keyToTXXX((TagLib::String const &)*arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
 }
+
+
+SWIGINTERN VALUE
+_wrap_UserTextIdentificationFrame_txxx_to_key(int argc, VALUE *argv, VALUE self) {
+  TagLib::String *arg1 = 0 ;
+  TagLib::String tmp1 ;
+  TagLib::String result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_string_to_taglib_string(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = TagLib::ID3v2::UserTextIdentificationFrame::txxxToKey((TagLib::String const &)*arg1);
+  {
+    vresult = taglib_string_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
 
 static swig_class SwigClassUniqueFileIdentifierFrame;
 
@@ -10733,9 +10875,9 @@ static swig_type_info _swigt__p_TagLib__ID3v2__AttachedPictureFrameV22 = {"_p_Ta
 static swig_type_info _swigt__p_TagLib__ID3v2__ChapterFrame = {"_p_TagLib__ID3v2__ChapterFrame", "TagLib::ID3v2::ChapterFrame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__CommentsFrame = {"_p_TagLib__ID3v2__CommentsFrame", "TagLib::ID3v2::CommentsFrame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__ExtendedHeader = {"_p_TagLib__ID3v2__ExtendedHeader", "TagLib::ID3v2::ExtendedHeader *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__ID3v2__Footer = {"_p_TagLib__ID3v2__Footer", "TagLib::ID3v2::Footer *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__Frame = {"_p_TagLib__ID3v2__Frame", "TagLib::ID3v2::Frame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__FrameFactory = {"_p_TagLib__ID3v2__FrameFactory", "TagLib::ID3v2::FrameFactory *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__ID3v2__Frame__Header = {"_p_TagLib__ID3v2__Frame__Header", "TagLib::ID3v2::Frame::Header *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame = {"_p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame", "TagLib::ID3v2::GeneralEncapsulatedObjectFrame *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__Header = {"_p_TagLib__ID3v2__Header", "TagLib::ID3v2::Header *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__PopularimeterFrame = {"_p_TagLib__ID3v2__PopularimeterFrame", "TagLib::ID3v2::PopularimeterFrame *", 0, 0, (void*)0, 0};
@@ -10754,6 +10896,7 @@ static swig_type_info _swigt__p_TagLib__ID3v2__UserUrlLinkFrame = {"_p_TagLib__I
 static swig_type_info _swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t = {"_p_TagLib__ListT_TagLib__ID3v2__Frame_p_t", "TagLib::ID3v2::FrameList *|TagLib::List< TagLib::ID3v2::Frame * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -10769,9 +10912,9 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__ID3v2__ChapterFrame,
   &_swigt__p_TagLib__ID3v2__CommentsFrame,
   &_swigt__p_TagLib__ID3v2__ExtendedHeader,
-  &_swigt__p_TagLib__ID3v2__Footer,
   &_swigt__p_TagLib__ID3v2__Frame,
   &_swigt__p_TagLib__ID3v2__FrameFactory,
+  &_swigt__p_TagLib__ID3v2__Frame__Header,
   &_swigt__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame,
   &_swigt__p_TagLib__ID3v2__Header,
   &_swigt__p_TagLib__ID3v2__PopularimeterFrame,
@@ -10790,6 +10933,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -10805,9 +10949,9 @@ static swig_cast_info _swigc__p_TagLib__ID3v2__AttachedPictureFrameV22[] = {  {&
 static swig_cast_info _swigc__p_TagLib__ID3v2__ChapterFrame[] = {  {&_swigt__p_TagLib__ID3v2__ChapterFrame, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__CommentsFrame[] = {  {&_swigt__p_TagLib__ID3v2__CommentsFrame, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__ExtendedHeader[] = {  {&_swigt__p_TagLib__ID3v2__ExtendedHeader, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_TagLib__ID3v2__Footer[] = {  {&_swigt__p_TagLib__ID3v2__Footer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__Frame[] = {  {&_swigt__p_TagLib__ID3v2__Frame, 0, 0, 0},  {&_swigt__p_TagLib__ID3v2__AttachedPictureFrame, _p_TagLib__ID3v2__AttachedPictureFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__AttachedPictureFrameV22, _p_TagLib__ID3v2__AttachedPictureFrameV22To_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__ChapterFrame, _p_TagLib__ID3v2__ChapterFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__CommentsFrame, _p_TagLib__ID3v2__CommentsFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame, _p_TagLib__ID3v2__GeneralEncapsulatedObjectFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__PopularimeterFrame, _p_TagLib__ID3v2__PopularimeterFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__PrivateFrame, _p_TagLib__ID3v2__PrivateFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__RelativeVolumeFrame, _p_TagLib__ID3v2__RelativeVolumeFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__TableOfContentsFrame, _p_TagLib__ID3v2__TableOfContentsFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__TextIdentificationFrame, _p_TagLib__ID3v2__TextIdentificationFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UniqueFileIdentifierFrame, _p_TagLib__ID3v2__UniqueFileIdentifierFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UnknownFrame, _p_TagLib__ID3v2__UnknownFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UnsynchronizedLyricsFrame, _p_TagLib__ID3v2__UnsynchronizedLyricsFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UrlLinkFrame, _p_TagLib__ID3v2__UrlLinkFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UserTextIdentificationFrame, _p_TagLib__ID3v2__UserTextIdentificationFrameTo_p_TagLib__ID3v2__Frame, 0, 0},  {&_swigt__p_TagLib__ID3v2__UserUrlLinkFrame, _p_TagLib__ID3v2__UserUrlLinkFrameTo_p_TagLib__ID3v2__Frame, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__FrameFactory[] = {  {&_swigt__p_TagLib__ID3v2__FrameFactory, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__ID3v2__Frame__Header[] = {  {&_swigt__p_TagLib__ID3v2__Frame__Header, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame[] = {  {&_swigt__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__Header[] = {  {&_swigt__p_TagLib__ID3v2__Header, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__PopularimeterFrame[] = {  {&_swigt__p_TagLib__ID3v2__PopularimeterFrame, 0, 0, 0},{0, 0, 0, 0}};
@@ -10826,6 +10970,7 @@ static swig_cast_info _swigc__p_TagLib__ID3v2__UserUrlLinkFrame[] = {  {&_swigt_
 static swig_cast_info _swigc__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t[] = {  {&_swigt__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},  {&_swigt__p_TagLib__ID3v2__Tag, _p_TagLib__ID3v2__TagTo_p_TagLib__Tag, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -10841,9 +10986,9 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__ID3v2__ChapterFrame,
   _swigc__p_TagLib__ID3v2__CommentsFrame,
   _swigc__p_TagLib__ID3v2__ExtendedHeader,
-  _swigc__p_TagLib__ID3v2__Footer,
   _swigc__p_TagLib__ID3v2__Frame,
   _swigc__p_TagLib__ID3v2__FrameFactory,
+  _swigc__p_TagLib__ID3v2__Frame__Header,
   _swigc__p_TagLib__ID3v2__GeneralEncapsulatedObjectFrame,
   _swigc__p_TagLib__ID3v2__Header,
   _swigc__p_TagLib__ID3v2__PopularimeterFrame,
@@ -10862,6 +11007,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__ListT_TagLib__ID3v2__Frame_p_t,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -11125,6 +11271,8 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   
   SWIG_RubyInitializeTrackings();
   rb_require("taglib_base");
+  rb_define_const(mID3v2, "V3", SWIG_From_int(static_cast< int >(TagLib::ID3v2::v3)));
+  rb_define_const(mID3v2, "V4", SWIG_From_int(static_cast< int >(TagLib::ID3v2::v4)));
   
   SwigClassHeader.klass = rb_define_class_under(mID3v2, "Header", rb_cObject);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__ID3v2__Header, (void *) &SwigClassHeader);
@@ -11156,8 +11304,12 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_method(SwigClassFrame.klass, "data=", VALUEFUNC(_wrap_Frame_datae___), -1);
   rb_define_method(SwigClassFrame.klass, "text=", VALUEFUNC(_wrap_Frame_texte___), -1);
   rb_define_method(SwigClassFrame.klass, "to_string", VALUEFUNC(_wrap_Frame_to_string), -1);
+  rb_define_method(SwigClassFrame.klass, "to_string_list", VALUEFUNC(_wrap_Frame_to_string_list), -1);
   rb_define_method(SwigClassFrame.klass, "render", VALUEFUNC(_wrap_Frame_render), -1);
+  rb_define_method(SwigClassFrame.klass, "header", VALUEFUNC(_wrap_Frame_header), -1);
   rb_define_singleton_method(SwigClassFrame.klass, "text_delimiter", VALUEFUNC(_wrap_Frame_text_delimiter), -1);
+  rb_define_singleton_method(SwigClassFrame.klass, "key_to_frame_id", VALUEFUNC(_wrap_Frame_key_to_frame_id), -1);
+  rb_define_singleton_method(SwigClassFrame.klass, "frame_idto_key", VALUEFUNC(_wrap_Frame_frame_idto_key), -1);
   SwigClassFrame.mark = 0;
   SwigClassFrame.destroy = (void (*)(void *)) free_TagLib_ID3v2_Frame;
   SwigClassFrame.trackObjects = 1;
@@ -11183,7 +11335,6 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_method(SwigClassTag.klass, "empty?", VALUEFUNC(_wrap_Tag_emptyq___), -1);
   rb_define_method(SwigClassTag.klass, "header", VALUEFUNC(_wrap_Tag_header), -1);
   rb_define_method(SwigClassTag.klass, "extended_header", VALUEFUNC(_wrap_Tag_extended_header), -1);
-  rb_define_method(SwigClassTag.klass, "footer", VALUEFUNC(_wrap_Tag_footer), -1);
   rb_define_method(SwigClassTag.klass, "frame_list_map", VALUEFUNC(_wrap_Tag_frame_list_map), -1);
   rb_define_method(SwigClassTag.klass, "frame_list", VALUEFUNC(_wrap_Tag_frame_list), -1);
   rb_define_method(SwigClassTag.klass, "add_frame", VALUEFUNC(_wrap_Tag_add_frame), -1);
@@ -11198,8 +11349,10 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_undef_alloc_func(SwigClassFrameFactory.klass);
   rb_define_singleton_method(SwigClassFrameFactory.klass, "instance", VALUEFUNC(_wrap_FrameFactory_instance), -1);
   rb_define_method(SwigClassFrameFactory.klass, "create_frame", VALUEFUNC(_wrap_FrameFactory_create_frame), -1);
+  rb_define_method(SwigClassFrameFactory.klass, "create_frame_for_property", VALUEFUNC(_wrap_FrameFactory_create_frame_for_property), -1);
   rb_define_method(SwigClassFrameFactory.klass, "default_text_encoding", VALUEFUNC(_wrap_FrameFactory_default_text_encoding), -1);
   rb_define_method(SwigClassFrameFactory.klass, "default_text_encoding=", VALUEFUNC(_wrap_FrameFactory_default_text_encodinge___), -1);
+  rb_define_method(SwigClassFrameFactory.klass, "is_using_default_text_encoding", VALUEFUNC(_wrap_FrameFactory_is_using_default_text_encoding), -1);
   SwigClassFrameFactory.mark = 0;
   SwigClassFrameFactory.trackObjects = 1;
   
@@ -11218,8 +11371,6 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_const(SwigClassRelativeVolumeFrame.klass, "Subwoofer", SWIG_From_int(static_cast< int >(TagLib::ID3v2::RelativeVolumeFrame::Subwoofer)));
   rb_define_method(SwigClassRelativeVolumeFrame.klass, "to_string", VALUEFUNC(_wrap_RelativeVolumeFrame_to_string), -1);
   rb_define_method(SwigClassRelativeVolumeFrame.klass, "channels", VALUEFUNC(_wrap_RelativeVolumeFrame_channels), -1);
-  rb_define_method(SwigClassRelativeVolumeFrame.klass, "channel_type", VALUEFUNC(_wrap_RelativeVolumeFrame_channel_type), -1);
-  rb_define_method(SwigClassRelativeVolumeFrame.klass, "channel_type=", VALUEFUNC(_wrap_RelativeVolumeFrame_channel_typee___), -1);
   rb_define_method(SwigClassRelativeVolumeFrame.klass, "volume_adjustment_index", VALUEFUNC(_wrap_RelativeVolumeFrame_volume_adjustment_index), -1);
   rb_define_method(SwigClassRelativeVolumeFrame.klass, "set_volume_adjustment_index", VALUEFUNC(_wrap_RelativeVolumeFrame_set_volume_adjustment_index), -1);
   rb_define_method(SwigClassRelativeVolumeFrame.klass, "volume_adjustment", VALUEFUNC(_wrap_RelativeVolumeFrame_volume_adjustment), -1);
@@ -11243,6 +11394,8 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   SwigClassPeakVolume.mark = 0;
   SwigClassPeakVolume.destroy = (void (*)(void *)) free_TagLib_ID3v2_RelativeVolumeFrame_PeakVolume;
   SwigClassPeakVolume.trackObjects = 1;
+  rb_define_module_function(mID3v2, "picture_type_to_string", VALUEFUNC(_wrap_picture_type_to_string), -1);
+  rb_define_module_function(mID3v2, "picture_type_from_string", VALUEFUNC(_wrap_picture_type_from_string), -1);
   
   SwigClassAttachedPictureFrame.klass = rb_define_class_under(mID3v2, "AttachedPictureFrame", ((swig_class *) SWIGTYPE_p_TagLib__ID3v2__Frame->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__ID3v2__AttachedPictureFrame, (void *) &SwigClassAttachedPictureFrame);
@@ -11269,7 +11422,10 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_const(SwigClassAttachedPictureFrame.klass, "Illustration", SWIG_From_int(static_cast< int >(TagLib::ID3v2::AttachedPictureFrame::Illustration)));
   rb_define_const(SwigClassAttachedPictureFrame.klass, "BandLogo", SWIG_From_int(static_cast< int >(TagLib::ID3v2::AttachedPictureFrame::BandLogo)));
   rb_define_const(SwigClassAttachedPictureFrame.klass, "PublisherLogo", SWIG_From_int(static_cast< int >(TagLib::ID3v2::AttachedPictureFrame::PublisherLogo)));
+  rb_define_singleton_method(SwigClassAttachedPictureFrame.klass, "type_to_string", VALUEFUNC(_wrap_AttachedPictureFrame_type_to_string), -1);
+  rb_define_singleton_method(SwigClassAttachedPictureFrame.klass, "type_from_string", VALUEFUNC(_wrap_AttachedPictureFrame_type_from_string), -1);
   rb_define_method(SwigClassAttachedPictureFrame.klass, "to_string", VALUEFUNC(_wrap_AttachedPictureFrame_to_string), -1);
+  rb_define_method(SwigClassAttachedPictureFrame.klass, "to_string_list", VALUEFUNC(_wrap_AttachedPictureFrame_to_string_list), -1);
   rb_define_method(SwigClassAttachedPictureFrame.klass, "text_encoding", VALUEFUNC(_wrap_AttachedPictureFrame_text_encoding), -1);
   rb_define_method(SwigClassAttachedPictureFrame.klass, "text_encoding=", VALUEFUNC(_wrap_AttachedPictureFrame_text_encodinge___), -1);
   rb_define_method(SwigClassAttachedPictureFrame.klass, "mime_type", VALUEFUNC(_wrap_AttachedPictureFrame_mime_type), -1);
@@ -11339,6 +11495,7 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_alloc_func(SwigClassGeneralEncapsulatedObjectFrame.klass, _wrap_GeneralEncapsulatedObjectFrame_allocate);
   rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "initialize", VALUEFUNC(_wrap_new_GeneralEncapsulatedObjectFrame), -1);
   rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "to_string", VALUEFUNC(_wrap_GeneralEncapsulatedObjectFrame_to_string), -1);
+  rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "to_string_list", VALUEFUNC(_wrap_GeneralEncapsulatedObjectFrame_to_string_list), -1);
   rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "text_encoding", VALUEFUNC(_wrap_GeneralEncapsulatedObjectFrame_text_encoding), -1);
   rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "text_encoding=", VALUEFUNC(_wrap_GeneralEncapsulatedObjectFrame_text_encodinge___), -1);
   rb_define_method(SwigClassGeneralEncapsulatedObjectFrame.klass, "mime_type", VALUEFUNC(_wrap_GeneralEncapsulatedObjectFrame_mime_type), -1);
@@ -11358,6 +11515,7 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_alloc_func(SwigClassPopularimeterFrame.klass, _wrap_PopularimeterFrame_allocate);
   rb_define_method(SwigClassPopularimeterFrame.klass, "initialize", VALUEFUNC(_wrap_new_PopularimeterFrame), -1);
   rb_define_method(SwigClassPopularimeterFrame.klass, "to_string", VALUEFUNC(_wrap_PopularimeterFrame_to_string), -1);
+  rb_define_method(SwigClassPopularimeterFrame.klass, "to_string_list", VALUEFUNC(_wrap_PopularimeterFrame_to_string_list), -1);
   rb_define_method(SwigClassPopularimeterFrame.klass, "email", VALUEFUNC(_wrap_PopularimeterFrame_email), -1);
   rb_define_method(SwigClassPopularimeterFrame.klass, "email=", VALUEFUNC(_wrap_PopularimeterFrame_emaile___), -1);
   rb_define_method(SwigClassPopularimeterFrame.klass, "rating", VALUEFUNC(_wrap_PopularimeterFrame_rating), -1);
@@ -11415,6 +11573,7 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_method(SwigClassTextIdentificationFrame.klass, "field_list=", VALUEFUNC(_wrap_TextIdentificationFrame_field_liste___), -1);
   rb_define_method(SwigClassTextIdentificationFrame.klass, "text=", VALUEFUNC(_wrap_TextIdentificationFrame_texte___), -1);
   rb_define_method(SwigClassTextIdentificationFrame.klass, "to_string", VALUEFUNC(_wrap_TextIdentificationFrame_to_string), -1);
+  rb_define_method(SwigClassTextIdentificationFrame.klass, "to_string_list", VALUEFUNC(_wrap_TextIdentificationFrame_to_string_list), -1);
   rb_define_method(SwigClassTextIdentificationFrame.klass, "text_encoding", VALUEFUNC(_wrap_TextIdentificationFrame_text_encoding), -1);
   rb_define_method(SwigClassTextIdentificationFrame.klass, "text_encoding=", VALUEFUNC(_wrap_TextIdentificationFrame_text_encodinge___), -1);
   rb_define_method(SwigClassTextIdentificationFrame.klass, "field_list", VALUEFUNC(_wrap_TextIdentificationFrame_field_list), -1);
@@ -11429,10 +11588,11 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   rb_define_method(SwigClassUserTextIdentificationFrame.klass, "to_string", VALUEFUNC(_wrap_UserTextIdentificationFrame_to_string), -1);
   rb_define_method(SwigClassUserTextIdentificationFrame.klass, "description", VALUEFUNC(_wrap_UserTextIdentificationFrame_description), -1);
   rb_define_method(SwigClassUserTextIdentificationFrame.klass, "description=", VALUEFUNC(_wrap_UserTextIdentificationFrame_descriptione___), -1);
-  rb_define_method(SwigClassUserTextIdentificationFrame.klass, "field_list", VALUEFUNC(_wrap_UserTextIdentificationFrame_field_list), -1);
   rb_define_method(SwigClassUserTextIdentificationFrame.klass, "text=", VALUEFUNC(_wrap_UserTextIdentificationFrame_texte___), -1);
   rb_define_method(SwigClassUserTextIdentificationFrame.klass, "field_list=", VALUEFUNC(_wrap_UserTextIdentificationFrame_field_liste___), -1);
   rb_define_singleton_method(SwigClassUserTextIdentificationFrame.klass, "find", VALUEFUNC(_wrap_UserTextIdentificationFrame_find), -1);
+  rb_define_singleton_method(SwigClassUserTextIdentificationFrame.klass, "key_to_txxx", VALUEFUNC(_wrap_UserTextIdentificationFrame_key_to_txxx), -1);
+  rb_define_singleton_method(SwigClassUserTextIdentificationFrame.klass, "txxx_to_key", VALUEFUNC(_wrap_UserTextIdentificationFrame_txxx_to_key), -1);
   SwigClassUserTextIdentificationFrame.mark = 0;
   SwigClassUserTextIdentificationFrame.destroy = (void (*)(void *)) free_TagLib_ID3v2_UserTextIdentificationFrame;
   SwigClassUserTextIdentificationFrame.trackObjects = 1;

--- a/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
+++ b/ext/taglib_id3v2/taglib_id3v2_wrap.cxx
@@ -5310,54 +5310,6 @@ free_TagLib_ID3v2_RelativeVolumeFrame_PeakVolume(void *self) {
     delete arg1;
 }
 
-SWIGINTERN VALUE
-_wrap_picture_type_to_string(int argc, VALUE *argv, VALUE self) {
-  int arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  TagLib::String result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib::Utils::pictureTypeToString", 1, argv[0] ));
-  } 
-  arg1 = static_cast< int >(val1);
-  result = TagLib::Utils::pictureTypeToString(arg1);
-  {
-    vresult = taglib_string_to_ruby_string(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_picture_type_from_string(int argc, VALUE *argv, VALUE self) {
-  TagLib::String *arg1 = 0 ;
-  TagLib::String tmp1 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_string_to_taglib_string(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (int)TagLib::Utils::pictureTypeFromString((TagLib::String const &)*arg1);
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
 static swig_class SwigClassAttachedPictureFrame;
 
 SWIGINTERN VALUE
@@ -11394,8 +11346,6 @@ SWIGEXPORT void Init_taglib_id3v2(void) {
   SwigClassPeakVolume.mark = 0;
   SwigClassPeakVolume.destroy = (void (*)(void *)) free_TagLib_ID3v2_RelativeVolumeFrame_PeakVolume;
   SwigClassPeakVolume.trackObjects = 1;
-  rb_define_module_function(mID3v2, "picture_type_to_string", VALUEFUNC(_wrap_picture_type_to_string), -1);
-  rb_define_module_function(mID3v2, "picture_type_from_string", VALUEFUNC(_wrap_picture_type_from_string), -1);
   
   SwigClassAttachedPictureFrame.klass = rb_define_class_under(mID3v2, "AttachedPictureFrame", ((swig_class *) SWIGTYPE_p_TagLib__ID3v2__Frame->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__ID3v2__AttachedPictureFrame, (void *) &SwigClassAttachedPictureFrame);

--- a/ext/taglib_mp4/taglib_mp4.i
+++ b/ext/taglib_mp4/taglib_mp4.i
@@ -5,10 +5,6 @@
 #include <taglib/mp4properties.h>
 #include <taglib/mp4tag.h>
 #include <taglib/mp4atom.h>
-#include <taglib/tpicturetype.h>
-// To resolve some symbols, like AtomDataType in Item.
-using namespace TagLib::MP4;
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -86,16 +82,6 @@ namespace TagLib {
 %ignore TagLib::Map<TagLib::String, TagLib::MP4::Item>::erase(Iterator);
 %ignore TagLib::Map<TagLib::String, TagLib::MP4::Item>::erase(const TagLib::String &);
 
-%ignore TagLib::MP4::Tag::itemListMap; // Deprecated.
-
-%rename("__getitem__") TagLib::MP4::Tag::item;
-
-// We will create a safe version of these below in an %extend
-// TagLib::MP4::Tag::item does not need to be reimplemented as it return an Item by value.
-%ignore TagLib::MP4::Tag::setItem;
-%ignore TagLib::MP4::Tag::removeItem;
-
-%include <taglib/mp4tag.h>
 
 %typemap(out) TagLib::MP4::CoverArtList {
   $result = taglib_cover_art_list_to_ruby_array($1);
@@ -119,13 +105,32 @@ namespace TagLib {
 %ignore TagLib::MP4::Item::setAtomDataType;
 
 %warnfilter(SWIGWARN_PARSE_NAMED_NESTED_CLASS) IntPair;
+%ignore ItemMap;
 %include <taglib/mp4item.h>
+
+namespace TagLib {
+  namespace MP4 {
+    %template(ItemMap) ::TagLib::Map<String, Item>;
+  }
+}
+
+%ignore TagLib::MP4::Tag::itemListMap; // Deprecated.
+
+%rename("__getitem__") TagLib::MP4::Tag::item;
+
+// We will create a safe version of these below in an %extend
+// TagLib::MP4::Tag::item does not need to be reimplemented as it return an Item by value.
+%ignore TagLib::MP4::Tag::setItem;
+%ignore TagLib::MP4::Tag::removeItem;
+
+%include <taglib/mp4tag.h>
 
 %freefunc TagLib::MP4::File "free_taglib_mp4_file";
 
 // Ignore IOStream and all the constructors using it.
 %ignore IOStream;
 %ignore TagLib::MP4::File::File(IOStream *, bool, Properties::ReadStyle);
+%ignore TagLib::MP4::File::File(IOStream *, bool, Properties::ReadStyle, ItemFactory *);
 %ignore TagLib::MP4::File::File(IOStream *, bool);
 %ignore TagLib::MP4::File::File(IOStream *);
 %ignore TagLib::MP4::File::isSupported(IOStream *);
@@ -137,12 +142,6 @@ namespace TagLib {
 
 %rename("mp4_tag?") TagLib::MP4::File::hasMP4Tag;
 %include <taglib/mp4file.h>
-
-namespace TagLib {
-  namespace MP4 {
-    %template(ItemMap) ::TagLib::Map<String, Item>;
-  }
-}
 
 // Unlink Ruby objects from the deleted C++ objects. Otherwise Ruby code
 // that calls a method on a tag after the file is deleted segfaults.

--- a/ext/taglib_mp4/taglib_mp4.i
+++ b/ext/taglib_mp4/taglib_mp4.i
@@ -5,8 +5,10 @@
 #include <taglib/mp4properties.h>
 #include <taglib/mp4tag.h>
 #include <taglib/mp4atom.h>
+#include <taglib/tpicturetype.h>
 // To resolve some symbols, like AtomDataType in Item.
 using namespace TagLib::MP4;
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_mp4/taglib_mp4_wrap.cxx
+++ b/ext/taglib_mp4/taglib_mp4_wrap.cxx
@@ -1861,17 +1861,20 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__MP4__CoverArtList swig_types[5]
 #define SWIGTYPE_p_TagLib__MP4__File swig_types[6]
 #define SWIGTYPE_p_TagLib__MP4__Item swig_types[7]
-#define SWIGTYPE_p_TagLib__MP4__Properties swig_types[8]
-#define SWIGTYPE_p_TagLib__MP4__Tag swig_types[9]
-#define SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t swig_types[10]
-#define SWIGTYPE_p_TagLib__Tag swig_types[11]
-#define SWIGTYPE_p_char swig_types[12]
-#define SWIGTYPE_p_unsigned_char swig_types[13]
-#define SWIGTYPE_p_unsigned_int swig_types[14]
-#define SWIGTYPE_p_unsigned_long swig_types[15]
-#define SWIGTYPE_p_wchar_t swig_types[16]
-static swig_type_info *swig_types[18];
-static swig_module_info swig_module = {swig_types, 17, 0, 0, 0, 0};
+#define SWIGTYPE_p_TagLib__MP4__ItemFactory swig_types[8]
+#define SWIGTYPE_p_TagLib__MP4__Properties swig_types[9]
+#define SWIGTYPE_p_TagLib__MP4__Tag swig_types[10]
+#define SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t swig_types[11]
+#define SWIGTYPE_p_TagLib__Tag swig_types[12]
+#define SWIGTYPE_p_char swig_types[13]
+#define SWIGTYPE_p_long_long swig_types[14]
+#define SWIGTYPE_p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator swig_types[15]
+#define SWIGTYPE_p_unsigned_char swig_types[16]
+#define SWIGTYPE_p_unsigned_int swig_types[17]
+#define SWIGTYPE_p_unsigned_long swig_types[18]
+#define SWIGTYPE_p_wchar_t swig_types[19]
+static swig_type_info *swig_types[21];
+static swig_module_info swig_module = {swig_types, 20, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1946,8 +1949,6 @@ template <typename T> T SwigValueInit() {
 #include <taglib/mp4properties.h>
 #include <taglib/mp4tag.h>
 #include <taglib/mp4atom.h>
-// To resolve some symbols, like AtomDataType in Item.
-using namespace TagLib::MP4;
 
 
 #include <taglib/tstring.h>
@@ -1968,34 +1969,26 @@ using namespace TagLib::MP4;
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2084,6 +2077,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 static void unlink_taglib_mp4_item_map_iterator(const TagLib::MP4::ItemMap::ConstIterator &it) {
@@ -2207,20 +2207,6 @@ SWIG_From_bool  (bool value)
 }
 
 
-SWIGINTERNINLINE VALUE
-SWIG_From_unsigned_SS_long  (unsigned long value)
-{
-  return ULONG2NUM(value); 
-}
-
-
-SWIGINTERNINLINE VALUE
-SWIG_From_unsigned_SS_int  (unsigned int value)
-{    
-  return SWIG_From_unsigned_SS_long  (value);
-}
-
-
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -2302,38 +2288,6 @@ SWIG_AsVal_unsigned_SS_long (VALUE obj, unsigned long *val)
 
 
 SWIGINTERN int
-SWIG_AsVal_unsigned_SS_int (VALUE obj, unsigned int *val)
-{
-  unsigned long v;
-  int res = SWIG_AsVal_unsigned_SS_long (obj, &v);
-  if (SWIG_IsOK(res)) {
-    if ((v > UINT_MAX)) {
-      return SWIG_OverflowError;
-    } else {
-      if (val) *val = static_cast< unsigned int >(v);
-    }
-  }  
-  return res;
-}
-
-SWIGINTERN VALUE TagLib_MP4_Tag___setitem__(TagLib::MP4::Tag *self,TagLib::String const &string,TagLib::MP4::Item const &item){
-    TagLib::MP4::ItemMap::ConstIterator it = self->itemMap().find(string);
-    if (it != self->itemMap().end()) {
-      unlink_taglib_mp4_item_map_iterator(it);
-    }
-    self->setItem(string, item);
-    return Qnil;
-  }
-SWIGINTERN VALUE TagLib_MP4_Tag_remove_item(TagLib::MP4::Tag *self,TagLib::String const &string){
-    TagLib::MP4::ItemMap::ConstIterator it = self->itemMap().find(string);
-    if (it != self->itemMap().end()) {
-      unlink_taglib_mp4_item_map_iterator(it);
-      self->removeItem(string);
-    }
-    return Qnil;
-  }
-
-SWIGINTERN int
 SWIG_AsVal_unsigned_SS_char (VALUE obj, unsigned char *val)
 {
   unsigned long v;
@@ -2343,6 +2297,22 @@ SWIG_AsVal_unsigned_SS_char (VALUE obj, unsigned char *val)
       return SWIG_OverflowError;
     } else {
       if (val) *val = static_cast< unsigned char >(v);
+    }
+  }  
+  return res;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_int (VALUE obj, unsigned int *val)
+{
+  unsigned long v;
+  int res = SWIG_AsVal_unsigned_SS_long (obj, &v);
+  if (SWIG_IsOK(res)) {
+    if ((v > UINT_MAX)) {
+      return SWIG_OverflowError;
+    } else {
+      if (val) *val = static_cast< unsigned int >(v);
     }
   }  
   return res;
@@ -2407,7 +2377,21 @@ SWIG_AsVal_bool (VALUE obj, bool *val)
 
 
 SWIGINTERNINLINE VALUE
+SWIG_From_unsigned_SS_long  (unsigned long value)
+{
+  return ULONG2NUM(value); 
+}
+
+
+SWIGINTERNINLINE VALUE
 SWIG_From_unsigned_SS_char  (unsigned char value)
+{    
+  return SWIG_From_unsigned_SS_long  (value);
+}
+
+
+SWIGINTERNINLINE VALUE
+SWIG_From_unsigned_SS_int  (unsigned int value)
 {    
   return SWIG_From_unsigned_SS_long  (value);
 }
@@ -2444,9 +2428,6 @@ SWIGINTERN TagLib::MP4::Item *TagLib_MP4_Item_from_cover_art_list(TagLib::MP4::C
   }
 SWIGINTERN TagLib::MP4::Item *TagLib_MP4_Item_from_byte_vector_list(TagLib::ByteVectorList const &byte_vector_list){
     return new TagLib::MP4::Item(byte_vector_list);
-  }
-SWIGINTERN void TagLib_MP4_File_close(TagLib::MP4::File *self){
-    free_taglib_mp4_file(self);
   }
 SWIGINTERN VALUE TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__to_a(TagLib::Map< TagLib::String,TagLib::MP4::Item > *self){
       VALUE ary = rb_ary_new2(self->size());
@@ -2501,6 +2482,25 @@ SWIGINTERN VALUE TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg___insert(TagL
       self->insert(string, item);
       return Qnil;
     }
+SWIGINTERN VALUE TagLib_MP4_Tag___setitem__(TagLib::MP4::Tag *self,TagLib::String const &string,TagLib::MP4::Item const &item){
+    TagLib::MP4::ItemMap::ConstIterator it = self->itemMap().find(string);
+    if (it != self->itemMap().end()) {
+      unlink_taglib_mp4_item_map_iterator(it);
+    }
+    self->setItem(string, item);
+    return Qnil;
+  }
+SWIGINTERN VALUE TagLib_MP4_Tag_remove_item(TagLib::MP4::Tag *self,TagLib::String const &string){
+    TagLib::MP4::ItemMap::ConstIterator it = self->itemMap().find(string);
+    if (it != self->itemMap().end()) {
+      unlink_taglib_mp4_item_map_iterator(it);
+      self->removeItem(string);
+    }
+    return Qnil;
+  }
+SWIGINTERN void TagLib_MP4_File_close(TagLib::MP4::File *self){
+    free_taglib_mp4_file(self);
+  }
 
   static void free_taglib_mp4_file(void *ptr) {
     TagLib::MP4::File *file = (TagLib::MP4::File *) ptr;
@@ -2558,7 +2558,7 @@ _wrap_new_Properties__SWIG_0(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< TagLib::MP4::File * >(argp1);
   res2 = SWIG_ConvertPtr(argv[1], &argp2,SWIGTYPE_p_TagLib__MP4__Atoms, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Atoms *","Properties", 2, argv[1] )); 
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Atoms const *","Properties", 2, argv[1] )); 
   }
   arg2 = reinterpret_cast< TagLib::MP4::Atoms * >(argp2);
   ecode3 = SWIG_AsVal_int(argv[2], &val3);
@@ -2566,7 +2566,7 @@ _wrap_new_Properties__SWIG_0(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::AudioProperties::ReadStyle","Properties", 3, argv[2] ));
   } 
   arg3 = static_cast< TagLib::AudioProperties::ReadStyle >(val3);
-  result = (TagLib::MP4::Properties *)new TagLib::MP4::Properties(arg1,arg2,arg3);
+  result = (TagLib::MP4::Properties *)new TagLib::MP4::Properties(arg1,(TagLib::MP4::Atoms const *)arg2,arg3);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
   return self;
@@ -2610,10 +2610,10 @@ _wrap_new_Properties__SWIG_1(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< TagLib::MP4::File * >(argp1);
   res2 = SWIG_ConvertPtr(argv[1], &argp2,SWIGTYPE_p_TagLib__MP4__Atoms, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Atoms *","Properties", 2, argv[1] )); 
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Atoms const *","Properties", 2, argv[1] )); 
   }
   arg2 = reinterpret_cast< TagLib::MP4::Atoms * >(argp2);
-  result = (TagLib::MP4::Properties *)new TagLib::MP4::Properties(arg1,arg2);
+  result = (TagLib::MP4::Properties *)new TagLib::MP4::Properties(arg1,(TagLib::MP4::Atoms const *)arg2);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
   return self;
@@ -2669,8 +2669,8 @@ SWIGINTERN VALUE _wrap_new_Properties(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Properties.new", 
-    "    Properties.new(TagLib::MP4::File *file, TagLib::MP4::Atoms *atoms, TagLib::AudioProperties::ReadStyle style)\n"
-    "    Properties.new(TagLib::MP4::File *file, TagLib::MP4::Atoms *atoms)\n");
+    "    Properties.new(TagLib::MP4::File *file, TagLib::MP4::Atoms const *atoms, TagLib::AudioProperties::ReadStyle style)\n"
+    "    Properties.new(TagLib::MP4::File *file, TagLib::MP4::Atoms const *atoms)\n");
   
   return Qnil;
 }
@@ -2682,30 +2682,6 @@ free_TagLib_MP4_Properties(void *self) {
     SWIG_RubyRemoveTracking(arg1);
     delete arg1;
 }
-
-SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Properties *arg1 = (TagLib::MP4::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Properties * >(argp1);
-  result = (int)((TagLib::MP4::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
 
 SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
@@ -2875,6 +2851,1781 @@ fail:
 }
 
 
+static swig_class SwigClassCoverArt;
+
+SWIGINTERN VALUE
+_wrap_new_CoverArt__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArt::Format arg1 ;
+  TagLib::ByteVector *arg2 = 0 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::ByteVector tmp2 ;
+  TagLib::MP4::CoverArt *result = 0 ;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt::Format","CoverArt", 1, argv[0] ));
+  } 
+  arg1 = static_cast< TagLib::MP4::CoverArt::Format >(val1);
+  {
+    tmp2 = ruby_string_to_taglib_bytevector(argv[1]);
+    arg2 = &tmp2;
+  }
+  result = (TagLib::MP4::CoverArt *)new TagLib::MP4::CoverArt(arg1,(TagLib::ByteVector const &)*arg2);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN void
+free_TagLib_MP4_CoverArt(void *self) {
+    TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *)self;
+    SWIG_RubyRemoveTracking(arg1);
+    delete arg1;
+}
+
+SWIGINTERN VALUE
+#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
+_wrap_CoverArt_allocate(VALUE self)
+#else
+_wrap_CoverArt_allocate(int argc, VALUE *argv, VALUE self)
+#endif
+{
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MP4__CoverArt);
+#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
+  rb_obj_call_init(vresult, argc, argv);
+#endif
+  return vresult;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_CoverArt__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArt *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::CoverArt *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MP4__CoverArt,  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const &","CoverArt", 1, argv[0] )); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::CoverArt const &","CoverArt", 1, argv[0])); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
+  result = (TagLib::MP4::CoverArt *)new TagLib::MP4::CoverArt((TagLib::MP4::CoverArt const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_new_CoverArt(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[2];
+  int ii;
+  
+  argc = nargs;
+  if (argc > 2) SWIG_fail;
+  for (ii = 0; (ii < argc); ++ii) {
+    argv[ii] = args[ii];
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__CoverArt, SWIG_POINTER_NO_NULL);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_CoverArt__SWIG_1(nargs, args, self);
+    }
+  }
+  if (argc == 2) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_new_CoverArt__SWIG_0(nargs, args, self);
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 2, "CoverArt.new", 
+    "    CoverArt.new(TagLib::MP4::CoverArt::Format format, TagLib::ByteVector const &data)\n"
+    "    CoverArt.new(TagLib::MP4::CoverArt const &item)\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_CoverArt_format(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::CoverArt::Format result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__CoverArt, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const *","format", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
+  result = (TagLib::MP4::CoverArt::Format)((TagLib::MP4::CoverArt const *)arg1)->format();
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_CoverArt_data(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::ByteVector result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__CoverArt, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const *","data", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
+  result = ((TagLib::MP4::CoverArt const *)arg1)->data();
+  {
+    vresult = taglib_bytevector_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+/*
+  Document-method: TagLib::MP4::CoverArt.==
+
+  call-seq:
+    ==(other) -> bool
+
+Equality comparison operator.
+*/
+SWIGINTERN VALUE
+_wrap_CoverArt___eq__(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *) 0 ;
+  TagLib::MP4::CoverArt *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__CoverArt, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const *","operator ==", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_TagLib__MP4__CoverArt,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const &","operator ==", 2, argv[0] )); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::CoverArt const &","operator ==", 2, argv[0])); 
+  }
+  arg2 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp2);
+  result = (bool)((TagLib::MP4::CoverArt const *)arg1)->operator ==((TagLib::MP4::CoverArt const &)*arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+static swig_class SwigClassItem;
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item();
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MP4__Item,  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","Item", 1, argv[0] )); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","Item", 1, argv[0])); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::MP4::Item const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN void
+free_TagLib_MP4_Item(void *self) {
+    TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *)self;
+    SWIG_RubyRemoveTracking(arg1);
+    delete arg1;
+}
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_2(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_3(int argc, VALUE *argv, VALUE self) {
+  unsigned char arg1 ;
+  unsigned char val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_unsigned_SS_char(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned char","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< unsigned char >(val1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_4(int argc, VALUE *argv, VALUE self) {
+  unsigned int arg1 ;
+  unsigned int val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_unsigned_SS_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned int","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< unsigned int >(val1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_5(int argc, VALUE *argv, VALUE self) {
+  long long arg1 ;
+  long long val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_long_SS_long(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "long long","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< long long >(val1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_6(int argc, VALUE *argv, VALUE self) {
+  bool arg1 ;
+  bool val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_bool(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "bool","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< bool >(val1);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_7(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int arg2 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Item", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  ecode2 = SWIG_AsVal_int(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","Item", 2, argv[1] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1,arg2);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_8(int argc, VALUE *argv, VALUE self) {
+  TagLib::StringList *arg1 = 0 ;
+  TagLib::StringList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_string_list(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::StringList const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_9(int argc, VALUE *argv, VALUE self) {
+  TagLib::ByteVectorList *arg1 = 0 ;
+  TagLib::ByteVectorList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_bytevectorlist(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::ByteVectorList const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
+_wrap_Item_allocate(VALUE self)
+#else
+_wrap_Item_allocate(int argc, VALUE *argv, VALUE self)
+#endif
+{
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MP4__Item);
+#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
+  rb_obj_call_init(vresult, argc, argv);
+#endif
+  return vresult;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Item__SWIG_10(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArtList *arg1 = 0 ;
+  TagLib::MP4::CoverArtList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_cover_art_list(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::MP4::CoverArtList const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_new_Item(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[2];
+  int ii;
+  
+  argc = nargs;
+  if (argc > 2) SWIG_fail;
+  for (ii = 0; (ii < argc); ++ii) {
+    argv[ii] = args[ii];
+  }
+  if (argc == 0) {
+    return _wrap_new_Item__SWIG_0(nargs, args, self);
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__Item, SWIG_POINTER_NO_NULL);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_Item__SWIG_1(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ByteVectorList, SWIG_POINTER_NO_NULL);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_Item__SWIG_9(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__CoverArtList, SWIG_POINTER_NO_NULL);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_Item__SWIG_10(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_unsigned_SS_char(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_3(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_unsigned_SS_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_4(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_2(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_long_SS_long(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_5(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      _v = TYPE(argv[0]) == T_ARRAY ? 1 : 0;
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_8(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_bool(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Item__SWIG_6(nargs, args, self);
+    }
+  }
+  if (argc == 2) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_new_Item__SWIG_7(nargs, args, self);
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 2, "Item.new", 
+    "    Item.new()\n"
+    "    Item.new(TagLib::MP4::Item const &item)\n"
+    "    Item.new(int value)\n"
+    "    Item.new(unsigned char value)\n"
+    "    Item.new(unsigned int value)\n"
+    "    Item.new(long long value)\n"
+    "    Item.new(bool value)\n"
+    "    Item.new(int value1, int value2)\n"
+    "    Item.new(TagLib::StringList const &value)\n"
+    "    Item.new(TagLib::ByteVectorList const &value)\n"
+    "    Item.new(TagLib::MP4::CoverArtList const &value)\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_int(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toInt", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (int)((TagLib::MP4::Item const *)arg1)->toInt();
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_byte(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned char result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toByte", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (unsigned char)((TagLib::MP4::Item const *)arg1)->toByte();
+  vresult = SWIG_From_unsigned_SS_char(static_cast< unsigned char >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_uint(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toUInt", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (unsigned int)((TagLib::MP4::Item const *)arg1)->toUInt();
+  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_long_long(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long long result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toLongLong", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (long long)((TagLib::MP4::Item const *)arg1)->toLongLong();
+  vresult = SWIG_From_long_SS_long(static_cast< long long >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_bool(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toBool", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (bool)((TagLib::MP4::Item const *)arg1)->toBool();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_int_pair(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::Item::IntPair result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toIntPair", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = ((TagLib::MP4::Item const *)arg1)->toIntPair();
+  {
+    vresult = taglib_mp4_item_int_pair_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::StringList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toStringList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = ((TagLib::MP4::Item const *)arg1)->toStringList();
+  {
+    vresult = taglib_string_list_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_byte_vector_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::ByteVectorList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toByteVectorList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = ((TagLib::MP4::Item const *)arg1)->toByteVectorList();
+  {
+    vresult = taglib_bytevectorlist_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_to_cover_art_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::CoverArtList result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toCoverArtList", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = ((TagLib::MP4::Item const *)arg1)->toCoverArtList();
+  {
+    vresult = taglib_cover_art_list_to_ruby_array(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_validq___(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","isValid", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (bool)((TagLib::MP4::Item const *)arg1)->isValid();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_type(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MP4::Item::Type result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","type", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  result = (TagLib::MP4::Item::Type)((TagLib::MP4::Item const *)arg1)->type();
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+/*
+  Document-method: TagLib::MP4::Item.==
+
+  call-seq:
+    ==(other) -> bool
+
+Equality comparison operator.
+*/
+SWIGINTERN VALUE
+_wrap_Item___eq__(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
+  TagLib::MP4::Item *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","operator ==", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_TagLib__MP4__Item,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","operator ==", 2, argv[0] )); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","operator ==", 2, argv[0])); 
+  }
+  arg2 = reinterpret_cast< TagLib::MP4::Item * >(argp2);
+  result = (bool)((TagLib::MP4::Item const *)arg1)->operator ==((TagLib::MP4::Item const &)*arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_bool(int argc, VALUE *argv, VALUE self) {
+  bool arg1 ;
+  bool val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_bool(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "bool","TagLib_MP4_Item_from_bool", 1, argv[0] ));
+  } 
+  arg1 = static_cast< bool >(val1);
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_bool(arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_byte(int argc, VALUE *argv, VALUE self) {
+  unsigned char arg1 ;
+  unsigned char val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_unsigned_SS_char(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned char","TagLib_MP4_Item_from_byte", 1, argv[0] ));
+  } 
+  arg1 = static_cast< unsigned char >(val1);
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_byte(arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_uint(int argc, VALUE *argv, VALUE self) {
+  unsigned int arg1 ;
+  unsigned int val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_unsigned_SS_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned int","TagLib_MP4_Item_from_uint", 1, argv[0] ));
+  } 
+  arg1 = static_cast< unsigned int >(val1);
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_uint(arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_int(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib_MP4_Item_from_int", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_int(arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_long_long(int argc, VALUE *argv, VALUE self) {
+  long long arg1 ;
+  long long val1 ;
+  int ecode1 = 0 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_long_SS_long(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "long long","TagLib_MP4_Item_from_long_long", 1, argv[0] ));
+  } 
+  arg1 = static_cast< long long >(val1);
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_long_long(arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_string_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::StringList *arg1 = 0 ;
+  TagLib::StringList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_string_list(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_string_list((TagLib::StringList const &)*arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_cover_art_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::CoverArtList *arg1 = 0 ;
+  TagLib::MP4::CoverArtList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_cover_art_list(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_cover_art_list((TagLib::MP4::CoverArtList const &)*arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Item_from_byte_vector_list(int argc, VALUE *argv, VALUE self) {
+  TagLib::ByteVectorList *arg1 = 0 ;
+  TagLib::ByteVectorList tmp1 ;
+  TagLib::MP4::Item *result = 0 ;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  {
+    tmp1 = ruby_array_to_taglib_bytevectorlist(argv[0]);
+    arg1 = &tmp1;
+  }
+  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_byte_vector_list((TagLib::ByteVectorList const &)*arg1);
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+static swig_class SwigClassItemMap;
+
+SWIGINTERN VALUE
+_wrap_new_ItemMap__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *result = 0 ;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  result = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)new TagLib::Map< TagLib::String,TagLib::MP4::Item >();
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_ItemMap__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","Map<(TagLib::String,TagLib::MP4::Item)>", 1, argv[0] )); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","Map<(TagLib::String,TagLib::MP4::Item)>", 1, argv[0])); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)new TagLib::Map< TagLib::String,TagLib::MP4::Item >((TagLib::Map< TagLib::String,TagLib::MP4::Item > const &)*arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
+_wrap_ItemMap_allocate(VALUE self)
+#else
+_wrap_ItemMap_allocate(int argc, VALUE *argv, VALUE self)
+#endif
+{
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t);
+#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
+  rb_obj_call_init(vresult, argc, argv);
+#endif
+  return vresult;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_ItemMap__SWIG_2(int argc, VALUE *argv, VALUE self) {
+  SwigValueWrapper< std::initializer_list< std::pair< TagLib::String const,TagLib::MP4::Item > > > arg1 ;
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  
+  result = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)new TagLib::Map< TagLib::String,TagLib::MP4::Item >(arg1);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_new_ItemMap(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[1];
+  int ii;
+  
+  argc = nargs;
+  if (argc > 1) SWIG_fail;
+  for (ii = 0; (ii < argc); ++ii) {
+    argv[ii] = args[ii];
+  }
+  if (argc == 0) {
+    return _wrap_new_ItemMap__SWIG_0(nargs, args, self);
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, SWIG_POINTER_NO_NULL);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_ItemMap__SWIG_1(nargs, args, self);
+    }
+  }
+  if (argc == 1) {
+    int _v = 0;
+    
+    if (_v) {
+      return _wrap_new_ItemMap__SWIG_2(nargs, args, self);
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 1, "ItemMap.new", 
+    "    ItemMap.new()\n"
+    "    ItemMap.new(TagLib::Map< TagLib::String,TagLib::MP4::Item > const &m)\n"
+    "    ItemMap.new(std::initializer_list< std::pair< TagLib::String const,TagLib::MP4::Item > > init)\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN void
+free_TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg_(void *self) {
+    TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)self;
+    SWIG_RubyRemoveTracking(arg1);
+    delete arg1;
+}
+
+SWIGINTERN VALUE
+_wrap_ItemMap_cbegin(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  SwigValueWrapper< std::map< TagLib::String,TagLib::MP4::Item >::const_iterator > result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","cbegin", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = ((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->cbegin();
+  vresult = SWIG_NewPointerObj((new TagLib::Map< TagLib::String,TagLib::MP4::Item >::ConstIterator(result)), SWIGTYPE_p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_cend(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  SwigValueWrapper< std::map< TagLib::String,TagLib::MP4::Item >::const_iterator > result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","cend", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = ((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->cend();
+  vresult = SWIG_NewPointerObj((new TagLib::Map< TagLib::String,TagLib::MP4::Item >::ConstIterator(result)), SWIGTYPE_p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+/*
+  Document-method: TagLib::MP4::ItemMap.size
+
+  call-seq:
+    size -> unsigned int
+
+Size or Length of the ItemMap.
+*/
+SWIGINTERN VALUE
+_wrap_ItemMap_size(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","size", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (unsigned int)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->size();
+  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_emptyq___(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","isEmpty", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (bool)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->isEmpty();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_contains(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","contains", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  result = (bool)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->contains((TagLib::String const &)*arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_value__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  TagLib::MP4::Item *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  TagLib::MP4::Item result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","value", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  res3 = SWIG_ConvertPtr(argv[1], &argp3, SWIGTYPE_p_TagLib__MP4__Item,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","value", 3, argv[1] )); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","value", 3, argv[1])); 
+  }
+  arg3 = reinterpret_cast< TagLib::MP4::Item * >(argp3);
+  result = ((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->value((TagLib::String const &)*arg2,(TagLib::MP4::Item const &)*arg3);
+  vresult = SWIG_NewPointerObj((new TagLib::MP4::Item(result)), SWIGTYPE_p_TagLib__MP4__Item, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_value__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  TagLib::MP4::Item result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","value", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  result = ((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->value((TagLib::String const &)*arg2);
+  vresult = SWIG_NewPointerObj((new TagLib::MP4::Item(result)), SWIGTYPE_p_TagLib__MP4__Item, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_ItemMap_value(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[4];
+  int ii;
+  
+  argc = nargs + 1;
+  argv[0] = self;
+  if (argc > 4) SWIG_fail;
+  for (ii = 1; (ii < argc); ++ii) {
+    argv[ii] = args[ii-1];
+  }
+  if (argc == 2) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_ItemMap_value__SWIG_1(nargs, args, self);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_TagLib__MP4__Item, SWIG_POINTER_NO_NULL);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_ItemMap_value__SWIG_0(nargs, args, self);
+        }
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 4, "ItemMap.value", 
+    "    TagLib::MP4::Item ItemMap.value(TagLib::String const &key, TagLib::MP4::Item const &defaultValue)\n"
+    "    TagLib::MP4::Item ItemMap.value(TagLib::String const &key)\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_swap(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","swap", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > &","swap", 2, argv[0] )); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::Map< TagLib::String,TagLib::MP4::Item > &","swap", 2, argv[0])); 
+  }
+  arg2 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp2);
+  (arg1)->swap(*arg2);
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+/*
+  Document-method: TagLib::MP4::ItemMap.==
+
+  call-seq:
+    ==(m) -> bool
+
+Equality comparison operator.
+*/
+SWIGINTERN VALUE
+_wrap_ItemMap___eq__(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","operator ==", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","operator ==", 2, argv[0] )); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","operator ==", 2, argv[0])); 
+  }
+  arg2 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp2);
+  result = (bool)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->operator ==((TagLib::Map< TagLib::String,TagLib::MP4::Item > const &)*arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+/*
+  Document-method: TagLib::MP4::ItemMap.to_a
+
+  call-seq:
+    to_a -> VALUE
+
+Convert ItemMap to an Array.
+*/
+SWIGINTERN VALUE
+_wrap_ItemMap_to_a(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","to_a", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__to_a(arg1);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_to_h(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","to_h", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__to_h(arg1);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_fetch(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","fetch", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__fetch(arg1,(TagLib::String const &)*arg2);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap__clear(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","_clear", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg___clear(arg1);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap_erase(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","erase", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__erase(arg1,(TagLib::String const &)*arg2);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_ItemMap__insert(int argc, VALUE *argv, VALUE self) {
+  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
+  TagLib::String *arg2 = 0 ;
+  TagLib::MP4::Item *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::String tmp2 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  VALUE result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","_insert", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
+  {
+    tmp2 = ruby_string_to_taglib_string(argv[0]);
+    arg2 = &tmp2;
+  }
+  res3 = SWIG_ConvertPtr(argv[1], &argp3, SWIGTYPE_p_TagLib__MP4__Item,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","_insert", 3, argv[1] )); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","_insert", 3, argv[1])); 
+  }
+  arg3 = reinterpret_cast< TagLib::MP4::Item * >(argp3);
+  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg___insert(arg1,(TagLib::String const &)*arg2,(TagLib::MP4::Item const &)*arg3);
+  vresult = result;
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassTag;
 
 SWIGINTERN VALUE
@@ -2885,6 +4636,46 @@ _wrap_new_Tag__SWIG_0(int argc, VALUE *argv, VALUE self) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
   }
   result = (TagLib::MP4::Tag *)new TagLib::MP4::Tag();
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::File *arg1 = (TagLib::File *) 0 ;
+  TagLib::MP4::Atoms *arg2 = (TagLib::MP4::Atoms *) 0 ;
+  TagLib::MP4::ItemFactory *arg3 = (TagLib::MP4::ItemFactory *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  TagLib::MP4::Tag *result = 0 ;
+  
+  if ((argc < 3) || (argc > 3)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Tag", 1, argv[0] )); 
+  }
+  arg1 = reinterpret_cast< TagLib::File * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[1], &argp2,SWIGTYPE_p_TagLib__MP4__Atoms, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::MP4::Atoms *","Tag", 2, argv[1] )); 
+  }
+  arg2 = reinterpret_cast< TagLib::MP4::Atoms * >(argp2);
+  res3 = SWIG_ConvertPtr(argv[2], &argp3,SWIGTYPE_p_TagLib__MP4__ItemFactory, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::MP4::ItemFactory const *","Tag", 3, argv[2] )); 
+  }
+  arg3 = reinterpret_cast< TagLib::MP4::ItemFactory * >(argp3);
+  result = (TagLib::MP4::Tag *)new TagLib::MP4::Tag(arg1,arg2,(TagLib::MP4::ItemFactory const *)arg3);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
   return self;
@@ -2909,7 +4700,7 @@ _wrap_Tag_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_Tag__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_Tag__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::File *arg1 = (TagLib::File *) 0 ;
   TagLib::MP4::Atoms *arg2 = (TagLib::MP4::Atoms *) 0 ;
   void *argp1 = 0 ;
@@ -2942,11 +4733,11 @@ fail:
 
 SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
   int argc;
-  VALUE argv[2];
+  VALUE argv[3];
   int ii;
   
   argc = nargs;
-  if (argc > 2) SWIG_fail;
+  if (argc > 3) SWIG_fail;
   for (ii = 0; (ii < argc); ++ii) {
     argv[ii] = args[ii];
   }
@@ -2963,14 +4754,34 @@ SWIGINTERN VALUE _wrap_new_Tag(int nargs, VALUE *args, VALUE self) {
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__MP4__Atoms, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_new_Tag__SWIG_1(nargs, args, self);
+        return _wrap_new_Tag__SWIG_2(nargs, args, self);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__File, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__MP4__Atoms, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_TagLib__MP4__ItemFactory, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_new_Tag__SWIG_1(nargs, args, self);
+        }
       }
     }
   }
   
 fail:
-  Ruby_Format_OverloadedError( argc, 2, "Tag.new", 
+  Ruby_Format_OverloadedError( argc, 3, "Tag.new", 
     "    Tag.new()\n"
+    "    Tag.new(TagLib::File *file, TagLib::MP4::Atoms *atoms, TagLib::MP4::ItemFactory const *factory)\n"
     "    Tag.new(TagLib::File *file, TagLib::MP4::Atoms *atoms)\n");
   
   return Qnil;
@@ -3487,6 +5298,30 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_Tag_strip(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::Tag *arg1 = (TagLib::MP4::Tag *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Tag, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Tag *","strip", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::Tag * >(argp1);
+  result = (bool)(arg1)->strip();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 /*
   Document-method: TagLib::MP4::Tag.[]=
 
@@ -3566,1037 +5401,57 @@ fail:
 }
 
 
-static swig_class SwigClassCoverArt;
-
-SWIGINTERN VALUE
-_wrap_new_CoverArt__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArt::Format arg1 ;
-  TagLib::ByteVector *arg2 = 0 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  TagLib::ByteVector tmp2 ;
-  TagLib::MP4::CoverArt *result = 0 ;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt::Format","CoverArt", 1, argv[0] ));
-  } 
-  arg1 = static_cast< TagLib::MP4::CoverArt::Format >(val1);
-  {
-    tmp2 = ruby_string_to_taglib_bytevector(argv[1]);
-    arg2 = &tmp2;
-  }
-  result = (TagLib::MP4::CoverArt *)new TagLib::MP4::CoverArt(arg1,(TagLib::ByteVector const &)*arg2);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN void
-free_TagLib_MP4_CoverArt(void *self) {
-    TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *)self;
-    SWIG_RubyRemoveTracking(arg1);
-    delete arg1;
-}
-
-SWIGINTERN VALUE
-#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
-_wrap_CoverArt_allocate(VALUE self)
-#else
-_wrap_CoverArt_allocate(int argc, VALUE *argv, VALUE self)
-#endif
-{
-  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MP4__CoverArt);
-#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
-  rb_obj_call_init(vresult, argc, argv);
-#endif
-  return vresult;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_CoverArt__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArt *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::MP4::CoverArt *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MP4__CoverArt,  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const &","CoverArt", 1, argv[0] )); 
-  }
-  if (!argp1) {
-    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::CoverArt const &","CoverArt", 1, argv[0])); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
-  result = (TagLib::MP4::CoverArt *)new TagLib::MP4::CoverArt((TagLib::MP4::CoverArt const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE _wrap_new_CoverArt(int nargs, VALUE *args, VALUE self) {
-  int argc;
-  VALUE argv[2];
-  int ii;
-  
-  argc = nargs;
-  if (argc > 2) SWIG_fail;
-  for (ii = 0; (ii < argc); ++ii) {
-    argv[ii] = args[ii];
-  }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__CoverArt, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_CoverArt__SWIG_1(nargs, args, self);
-    }
-  }
-  if (argc == 2) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_int(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_CoverArt__SWIG_0(nargs, args, self);
-      }
-    }
-  }
-  
-fail:
-  Ruby_Format_OverloadedError( argc, 2, "CoverArt.new", 
-    "    CoverArt.new(TagLib::MP4::CoverArt::Format format, TagLib::ByteVector const &data)\n"
-    "    CoverArt.new(TagLib::MP4::CoverArt const &item)\n");
-  
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_CoverArt_format(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::MP4::CoverArt::Format result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__CoverArt, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const *","format", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
-  result = (TagLib::MP4::CoverArt::Format)((TagLib::MP4::CoverArt const *)arg1)->format();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_CoverArt_data(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArt *arg1 = (TagLib::MP4::CoverArt *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__CoverArt, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::CoverArt const *","data", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::CoverArt * >(argp1);
-  result = ((TagLib::MP4::CoverArt const *)arg1)->data();
-  {
-    vresult = taglib_bytevector_to_ruby_string(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-static swig_class SwigClassItem;
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item();
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MP4__Item,  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","Item", 1, argv[0] )); 
-  }
-  if (!argp1) {
-    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","Item", 1, argv[0])); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::MP4::Item const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN void
-free_TagLib_MP4_Item(void *self) {
-    TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *)self;
-    SWIG_RubyRemoveTracking(arg1);
-    delete arg1;
-}
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  int arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< int >(val1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_3(int argc, VALUE *argv, VALUE self) {
-  unsigned char arg1 ;
-  unsigned char val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_unsigned_SS_char(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned char","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< unsigned char >(val1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_4(int argc, VALUE *argv, VALUE self) {
-  unsigned int arg1 ;
-  unsigned int val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_unsigned_SS_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned int","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< unsigned int >(val1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_5(int argc, VALUE *argv, VALUE self) {
-  long long arg1 ;
-  long long val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_long_SS_long(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "long long","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< long long >(val1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_6(int argc, VALUE *argv, VALUE self) {
-  bool arg1 ;
-  bool val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_bool(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "bool","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< bool >(val1);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_7(int argc, VALUE *argv, VALUE self) {
-  int arg1 ;
-  int arg2 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Item", 1, argv[0] ));
-  } 
-  arg1 = static_cast< int >(val1);
-  ecode2 = SWIG_AsVal_int(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","Item", 2, argv[1] ));
-  } 
-  arg2 = static_cast< int >(val2);
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item(arg1,arg2);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_8(int argc, VALUE *argv, VALUE self) {
-  TagLib::StringList *arg1 = 0 ;
-  TagLib::StringList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_string_list(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::StringList const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_9(int argc, VALUE *argv, VALUE self) {
-  TagLib::ByteVectorList *arg1 = 0 ;
-  TagLib::ByteVectorList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_bytevectorlist(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::ByteVectorList const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
-_wrap_Item_allocate(VALUE self)
-#else
-_wrap_Item_allocate(int argc, VALUE *argv, VALUE self)
-#endif
-{
-  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MP4__Item);
-#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
-  rb_obj_call_init(vresult, argc, argv);
-#endif
-  return vresult;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Item__SWIG_10(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArtList *arg1 = 0 ;
-  TagLib::MP4::CoverArtList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_cover_art_list(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)new TagLib::MP4::Item((TagLib::MP4::CoverArtList const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE _wrap_new_Item(int nargs, VALUE *args, VALUE self) {
-  int argc;
-  VALUE argv[2];
-  int ii;
-  
-  argc = nargs;
-  if (argc > 2) SWIG_fail;
-  for (ii = 0; (ii < argc); ++ii) {
-    argv[ii] = args[ii];
-  }
-  if (argc == 0) {
-    return _wrap_new_Item__SWIG_0(nargs, args, self);
-  }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__Item, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Item__SWIG_1(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__ByteVectorList, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Item__SWIG_9(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__CoverArtList, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Item__SWIG_10(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_unsigned_SS_char(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_3(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_unsigned_SS_int(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_4(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_int(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_2(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_long_SS_long(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_5(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      _v = TYPE(argv[0]) == T_ARRAY ? 1 : 0;
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_8(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_bool(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      return _wrap_new_Item__SWIG_6(nargs, args, self);
-    }
-  }
-  if (argc == 2) {
-    int _v = 0;
-    {
-      int res = SWIG_AsVal_int(argv[0], NULL);
-      _v = SWIG_CheckState(res);
-    }
-    if (_v) {
-      {
-        int res = SWIG_AsVal_int(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_new_Item__SWIG_7(nargs, args, self);
-      }
-    }
-  }
-  
-fail:
-  Ruby_Format_OverloadedError( argc, 2, "Item.new", 
-    "    Item.new()\n"
-    "    Item.new(TagLib::MP4::Item const &item)\n"
-    "    Item.new(int value)\n"
-    "    Item.new(unsigned char value)\n"
-    "    Item.new(unsigned int value)\n"
-    "    Item.new(long long value)\n"
-    "    Item.new(bool value)\n"
-    "    Item.new(int first, int second)\n"
-    "    Item.new(TagLib::StringList const &value)\n"
-    "    Item.new(TagLib::ByteVectorList const &value)\n"
-    "    Item.new(TagLib::MP4::CoverArtList const &value)\n");
-  
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_int(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toInt", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (int)((TagLib::MP4::Item const *)arg1)->toInt();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_byte(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  unsigned char result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toByte", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (unsigned char)((TagLib::MP4::Item const *)arg1)->toByte();
-  vresult = SWIG_From_unsigned_SS_char(static_cast< unsigned char >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_uint(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  unsigned int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toUInt", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (unsigned int)((TagLib::MP4::Item const *)arg1)->toUInt();
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_long_long(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  long long result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toLongLong", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (long long)((TagLib::MP4::Item const *)arg1)->toLongLong();
-  vresult = SWIG_From_long_SS_long(static_cast< long long >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_bool(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toBool", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (bool)((TagLib::MP4::Item const *)arg1)->toBool();
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_int_pair(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::MP4::Item::IntPair result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toIntPair", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = ((TagLib::MP4::Item const *)arg1)->toIntPair();
-  {
-    vresult = taglib_mp4_item_int_pair_to_ruby_array(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_string_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::StringList result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toStringList", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = ((TagLib::MP4::Item const *)arg1)->toStringList();
-  {
-    vresult = taglib_string_list_to_ruby_array(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_byte_vector_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVectorList result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toByteVectorList", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = ((TagLib::MP4::Item const *)arg1)->toByteVectorList();
-  {
-    vresult = taglib_bytevectorlist_to_ruby_array(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_to_cover_art_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::MP4::CoverArtList result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","toCoverArtList", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = ((TagLib::MP4::Item const *)arg1)->toCoverArtList();
-  {
-    vresult = taglib_cover_art_list_to_ruby_array(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_validq___(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::Item *arg1 = (TagLib::MP4::Item *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::Item const *","isValid", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MP4::Item * >(argp1);
-  result = (bool)((TagLib::MP4::Item const *)arg1)->isValid();
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_bool(int argc, VALUE *argv, VALUE self) {
-  bool arg1 ;
-  bool val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_bool(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "bool","TagLib_MP4_Item_from_bool", 1, argv[0] ));
-  } 
-  arg1 = static_cast< bool >(val1);
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_bool(arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_byte(int argc, VALUE *argv, VALUE self) {
-  unsigned char arg1 ;
-  unsigned char val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_unsigned_SS_char(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned char","TagLib_MP4_Item_from_byte", 1, argv[0] ));
-  } 
-  arg1 = static_cast< unsigned char >(val1);
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_byte(arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_uint(int argc, VALUE *argv, VALUE self) {
-  unsigned int arg1 ;
-  unsigned int val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_unsigned_SS_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "unsigned int","TagLib_MP4_Item_from_uint", 1, argv[0] ));
-  } 
-  arg1 = static_cast< unsigned int >(val1);
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_uint(arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_int(int argc, VALUE *argv, VALUE self) {
-  int arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","TagLib_MP4_Item_from_int", 1, argv[0] ));
-  } 
-  arg1 = static_cast< int >(val1);
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_int(arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_long_long(int argc, VALUE *argv, VALUE self) {
-  long long arg1 ;
-  long long val1 ;
-  int ecode1 = 0 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_long_SS_long(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "long long","TagLib_MP4_Item_from_long_long", 1, argv[0] ));
-  } 
-  arg1 = static_cast< long long >(val1);
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_long_long(arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_string_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::StringList *arg1 = 0 ;
-  TagLib::StringList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_string_list(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_string_list((TagLib::StringList const &)*arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_cover_art_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::MP4::CoverArtList *arg1 = 0 ;
-  TagLib::MP4::CoverArtList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_cover_art_list(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_cover_art_list((TagLib::MP4::CoverArtList const &)*arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Item_from_byte_vector_list(int argc, VALUE *argv, VALUE self) {
-  TagLib::ByteVectorList *arg1 = 0 ;
-  TagLib::ByteVectorList tmp1 ;
-  TagLib::MP4::Item *result = 0 ;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_array_to_taglib_bytevectorlist(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MP4::Item *)TagLib_MP4_Item_from_byte_vector_list((TagLib::ByteVectorList const &)*arg1);
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__MP4__Item, 0 |  0 );
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
 static swig_class SwigClassFile;
 
 SWIGINTERN VALUE
 _wrap_new_File__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::FileName arg1 ;
+  bool arg2 ;
+  TagLib::MP4::Properties::ReadStyle arg3 ;
+  TagLib::MP4::ItemFactory *arg4 = (TagLib::MP4::ItemFactory *) 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  TagLib::MP4::File *result = 0 ;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  {
+    arg1 = ruby_string_to_taglib_filename(argv[0]);
+    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
+      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
+    }
+  }
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","File", 2, argv[1] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::MP4::Properties::ReadStyle","File", 3, argv[2] ));
+  } 
+  arg3 = static_cast< TagLib::MP4::Properties::ReadStyle >(val3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4,SWIGTYPE_p_TagLib__MP4__ItemFactory, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::MP4::ItemFactory *","File", 4, argv[3] )); 
+  }
+  arg4 = reinterpret_cast< TagLib::MP4::ItemFactory * >(argp4);
+  result = (TagLib::MP4::File *)new TagLib::MP4::File(arg1,arg2,arg3,arg4);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   TagLib::MP4::Properties::ReadStyle arg3 ;
@@ -4635,7 +5490,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   bool val2 ;
@@ -4681,7 +5536,7 @@ _wrap_File_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::MP4::File *result = 0 ;
   
@@ -4705,11 +5560,11 @@ fail:
 
 SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
   int argc;
-  VALUE argv[3];
+  VALUE argv[4];
   int ii;
   
   argc = nargs;
-  if (argc > 3) SWIG_fail;
+  if (argc > 4) SWIG_fail;
   for (ii = 0; (ii < argc); ++ii) {
     argv[ii] = args[ii];
   }
@@ -4718,7 +5573,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_File__SWIG_2(nargs, args, self);
+      return _wrap_new_File__SWIG_3(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -4731,7 +5586,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_File__SWIG_1(nargs, args, self);
+        return _wrap_new_File__SWIG_2(nargs, args, self);
       }
     }
   }
@@ -4750,14 +5605,40 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_0(nargs, args, self);
+          return _wrap_new_File__SWIG_1(nargs, args, self);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__MP4__ItemFactory, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_new_File__SWIG_0(nargs, args, self);
+          }
         }
       }
     }
   }
   
 fail:
-  Ruby_Format_OverloadedError( argc, 3, "File.new", 
+  Ruby_Format_OverloadedError( argc, 4, "File.new", 
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::MP4::Properties::ReadStyle audioPropertiesStyle, TagLib::MP4::ItemFactory *itemFactory)\n"
     "    File.new(TagLib::FileName file, bool readProperties, TagLib::MP4::Properties::ReadStyle audioPropertiesStyle)\n"
     "    File.new(TagLib::FileName file, bool readProperties)\n"
     "    File.new(TagLib::FileName file)\n");
@@ -4839,6 +5720,107 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_File_strip__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::File *arg1 = (TagLib::MP4::File *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::File *","strip", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::File * >(argp1);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","strip", 2, argv[0] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  result = (bool)(arg1)->strip(arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_strip__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::MP4::File *arg1 = (TagLib::MP4::File *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MP4__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MP4::File *","strip", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MP4::File * >(argp1);
+  result = (bool)(arg1)->strip();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[3];
+  int ii;
+  
+  argc = nargs + 1;
+  argv[0] = self;
+  if (argc > 3) SWIG_fail;
+  for (ii = 1; (ii < argc); ++ii) {
+    argv[ii] = args[ii-1];
+  }
+  if (argc == 1) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__File, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_File_strip__SWIG_1(nargs, args, self);
+    }
+  }
+  if (argc == 2) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MP4__File, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_File_strip__SWIG_0(nargs, args, self);
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 3, "File.strip", 
+    "    bool File.strip(int tags)\n"
+    "    bool File.strip()\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_File_mp4_tagq___(int argc, VALUE *argv, VALUE self) {
   TagLib::MP4::File *arg1 = (TagLib::MP4::File *) 0 ;
   void *argp1 = 0 ;
@@ -4883,372 +5865,6 @@ fail:
 }
 
 
-static swig_class SwigClassItemMap;
-
-SWIGINTERN VALUE
-_wrap_new_ItemMap__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *result = 0 ;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  result = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)new TagLib::Map< TagLib::String,TagLib::MP4::Item >();
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
-_wrap_ItemMap_allocate(VALUE self)
-#else
-_wrap_ItemMap_allocate(int argc, VALUE *argv, VALUE self)
-#endif
-{
-  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t);
-#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
-  rb_obj_call_init(vresult, argc, argv);
-#endif
-  return vresult;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_ItemMap__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","Map<(TagLib::String,TagLib::MP4::Item)>", 1, argv[0] )); 
-  }
-  if (!argp1) {
-    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const &","Map<(TagLib::String,TagLib::MP4::Item)>", 1, argv[0])); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)new TagLib::Map< TagLib::String,TagLib::MP4::Item >((TagLib::Map< TagLib::String,TagLib::MP4::Item > const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE _wrap_new_ItemMap(int nargs, VALUE *args, VALUE self) {
-  int argc;
-  VALUE argv[1];
-  int ii;
-  
-  argc = nargs;
-  if (argc > 1) SWIG_fail;
-  for (ii = 0; (ii < argc); ++ii) {
-    argv[ii] = args[ii];
-  }
-  if (argc == 0) {
-    return _wrap_new_ItemMap__SWIG_0(nargs, args, self);
-  }
-  if (argc == 1) {
-    int _v = 0;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_ItemMap__SWIG_1(nargs, args, self);
-    }
-  }
-  
-fail:
-  Ruby_Format_OverloadedError( argc, 1, "ItemMap.new", 
-    "    ItemMap.new()\n"
-    "    ItemMap.new(TagLib::Map< TagLib::String,TagLib::MP4::Item > const &m)\n");
-  
-  return Qnil;
-}
-
-
-SWIGINTERN void
-free_TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg_(void *self) {
-    TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *)self;
-    SWIG_RubyRemoveTracking(arg1);
-    delete arg1;
-}
-
-/*
-  Document-method: TagLib::MP4::ItemMap.size
-
-  call-seq:
-    size -> unsigned int
-
-Size or Length of the ItemMap.
-*/
-SWIGINTERN VALUE
-_wrap_ItemMap_size(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  unsigned int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","size", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (unsigned int)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->size();
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap_emptyq___(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","isEmpty", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (bool)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->isEmpty();
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap_contains(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  TagLib::String *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::String tmp2 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > const *","contains", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_string(argv[0]);
-    arg2 = &tmp2;
-  }
-  result = (bool)((TagLib::Map< TagLib::String,TagLib::MP4::Item > const *)arg1)->contains((TagLib::String const &)*arg2);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-/*
-  Document-method: TagLib::MP4::ItemMap.to_a
-
-  call-seq:
-    to_a -> VALUE
-
-Convert ItemMap to an Array.
-*/
-SWIGINTERN VALUE
-_wrap_ItemMap_to_a(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","to_a", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__to_a(arg1);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap_to_h(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","to_h", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__to_h(arg1);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap_fetch(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  TagLib::String *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::String tmp2 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","fetch", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_string(argv[0]);
-    arg2 = &tmp2;
-  }
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__fetch(arg1,(TagLib::String const &)*arg2);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap__clear(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","_clear", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg___clear(arg1);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap_erase(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  TagLib::String *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::String tmp2 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","erase", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_string(argv[0]);
-    arg2 = &tmp2;
-  }
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg__erase(arg1,(TagLib::String const &)*arg2);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_ItemMap__insert(int argc, VALUE *argv, VALUE self) {
-  TagLib::Map< TagLib::String,TagLib::MP4::Item > *arg1 = (TagLib::Map< TagLib::String,TagLib::MP4::Item > *) 0 ;
-  TagLib::String *arg2 = 0 ;
-  TagLib::MP4::Item *arg3 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::String tmp2 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
-  VALUE result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Map< TagLib::String,TagLib::MP4::Item > *","_insert", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Map< TagLib::String,TagLib::MP4::Item > * >(argp1);
-  {
-    tmp2 = ruby_string_to_taglib_string(argv[0]);
-    arg2 = &tmp2;
-  }
-  res3 = SWIG_ConvertPtr(argv[1], &argp3, SWIGTYPE_p_TagLib__MP4__Item,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), Ruby_Format_TypeError( "", "TagLib::MP4::Item const &","_insert", 3, argv[1] )); 
-  }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::MP4::Item const &","_insert", 3, argv[1])); 
-  }
-  arg3 = reinterpret_cast< TagLib::MP4::Item * >(argp3);
-  result = (VALUE)TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg___insert(arg1,(TagLib::String const &)*arg2,(TagLib::MP4::Item const &)*arg3);
-  vresult = result;
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
@@ -5269,11 +5885,14 @@ static swig_type_info _swigt__p_TagLib__MP4__CoverArt = {"_p_TagLib__MP4__CoverA
 static swig_type_info _swigt__p_TagLib__MP4__CoverArtList = {"_p_TagLib__MP4__CoverArtList", "TagLib::MP4::CoverArtList *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MP4__File = {"_p_TagLib__MP4__File", "TagLib::MP4::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MP4__Item = {"_p_TagLib__MP4__Item", "TagLib::MP4::Item *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__MP4__ItemFactory = {"_p_TagLib__MP4__ItemFactory", "TagLib::MP4::ItemFactory *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MP4__Properties = {"_p_TagLib__MP4__Properties", "TagLib::MP4::Properties *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__MP4__Tag = {"_p_TagLib__MP4__Tag", "TagLib::MP4::Tag *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t = {"_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t", "TagLib::MP4::ItemListMap *|TagLib::MP4::ItemMap *|TagLib::Map< TagLib::String,TagLib::MP4::Item > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t = {"_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t", "TagLib::MP4::ItemMap *|TagLib::Map< TagLib::String,TagLib::MP4::Item > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator = {"_p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator", "TagLib::Map< TagLib::String,TagLib::MP4::Item >::ConstIterator *|std::map< TagLib::String,TagLib::MP4::Item >::const_iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -5288,11 +5907,14 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__MP4__CoverArtList,
   &_swigt__p_TagLib__MP4__File,
   &_swigt__p_TagLib__MP4__Item,
+  &_swigt__p_TagLib__MP4__ItemFactory,
   &_swigt__p_TagLib__MP4__Properties,
   &_swigt__p_TagLib__MP4__Tag,
   &_swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
+  &_swigt__p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -5307,11 +5929,14 @@ static swig_cast_info _swigc__p_TagLib__MP4__CoverArt[] = {  {&_swigt__p_TagLib_
 static swig_cast_info _swigc__p_TagLib__MP4__CoverArtList[] = {  {&_swigt__p_TagLib__MP4__CoverArtList, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MP4__File[] = {  {&_swigt__p_TagLib__MP4__File, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MP4__Item[] = {  {&_swigt__p_TagLib__MP4__Item, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__MP4__ItemFactory[] = {  {&_swigt__p_TagLib__MP4__ItemFactory, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MP4__Properties[] = {  {&_swigt__p_TagLib__MP4__Properties, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MP4__Tag[] = {  {&_swigt__p_TagLib__MP4__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t[] = {  {&_swigt__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},  {&_swigt__p_TagLib__MP4__Tag, _p_TagLib__MP4__TagTo_p_TagLib__Tag, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator[] = {  {&_swigt__p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -5326,11 +5951,14 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__MP4__CoverArtList,
   _swigc__p_TagLib__MP4__File,
   _swigc__p_TagLib__MP4__Item,
+  _swigc__p_TagLib__MP4__ItemFactory,
   _swigc__p_TagLib__MP4__Properties,
   _swigc__p_TagLib__MP4__Tag,
   _swigc__p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
+  _swigc__p_std__mapT_TagLib__String_TagLib__MP4__Item_t__const_iterator,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -5602,7 +6230,6 @@ SWIGEXPORT void Init_taglib_mp4(void) {
   rb_define_const(SwigClassProperties.klass, "Unknown", SWIG_From_int(static_cast< int >(TagLib::MP4::Properties::Unknown)));
   rb_define_const(SwigClassProperties.klass, "AAC", SWIG_From_int(static_cast< int >(TagLib::MP4::Properties::AAC)));
   rb_define_const(SwigClassProperties.klass, "ALAC", SWIG_From_int(static_cast< int >(TagLib::MP4::Properties::ALAC)));
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);
@@ -5613,6 +6240,84 @@ SWIGEXPORT void Init_taglib_mp4(void) {
   SwigClassProperties.mark = 0;
   SwigClassProperties.destroy = (void (*)(void *)) free_TagLib_MP4_Properties;
   SwigClassProperties.trackObjects = 1;
+  
+  SwigClassCoverArt.klass = rb_define_class_under(mMP4, "CoverArt", rb_cObject);
+  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__CoverArt, (void *) &SwigClassCoverArt);
+  rb_define_alloc_func(SwigClassCoverArt.klass, _wrap_CoverArt_allocate);
+  rb_define_method(SwigClassCoverArt.klass, "initialize", VALUEFUNC(_wrap_new_CoverArt), -1);
+  rb_define_const(SwigClassCoverArt.klass, "JPEG", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::JPEG)));
+  rb_define_const(SwigClassCoverArt.klass, "PNG", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::PNG)));
+  rb_define_const(SwigClassCoverArt.klass, "BMP", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::BMP)));
+  rb_define_const(SwigClassCoverArt.klass, "GIF", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::GIF)));
+  rb_define_const(SwigClassCoverArt.klass, "Unknown", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::Unknown)));
+  rb_define_method(SwigClassCoverArt.klass, "format", VALUEFUNC(_wrap_CoverArt_format), -1);
+  rb_define_method(SwigClassCoverArt.klass, "data", VALUEFUNC(_wrap_CoverArt_data), -1);
+  rb_define_method(SwigClassCoverArt.klass, "==", VALUEFUNC(_wrap_CoverArt___eq__), -1);
+  SwigClassCoverArt.mark = 0;
+  SwigClassCoverArt.destroy = (void (*)(void *)) free_TagLib_MP4_CoverArt;
+  SwigClassCoverArt.trackObjects = 1;
+  
+  SwigClassItem.klass = rb_define_class_under(mMP4, "Item", rb_cObject);
+  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__Item, (void *) &SwigClassItem);
+  rb_define_alloc_func(SwigClassItem.klass, _wrap_Item_allocate);
+  rb_define_method(SwigClassItem.klass, "initialize", VALUEFUNC(_wrap_new_Item), -1);
+  rb_define_const(SwigClassItem.klass, "Type_Void", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::Void)));
+  rb_define_const(SwigClassItem.klass, "Type_Bool", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::Bool)));
+  rb_define_const(SwigClassItem.klass, "Type_Int", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::Int)));
+  rb_define_const(SwigClassItem.klass, "Type_IntPair", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::IntPair)));
+  rb_define_const(SwigClassItem.klass, "Type_Byte", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::Byte)));
+  rb_define_const(SwigClassItem.klass, "Type_UInt", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::UInt)));
+  rb_define_const(SwigClassItem.klass, "Type_LongLong", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::LongLong)));
+  rb_define_const(SwigClassItem.klass, "Type_StringList", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::StringList)));
+  rb_define_const(SwigClassItem.klass, "Type_ByteVectorList", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::ByteVectorList)));
+  rb_define_const(SwigClassItem.klass, "Type_CoverArtList", SWIG_From_int(static_cast< int >(TagLib::MP4::Item::Type::CoverArtList)));
+  rb_define_method(SwigClassItem.klass, "to_int", VALUEFUNC(_wrap_Item_to_int), -1);
+  rb_define_method(SwigClassItem.klass, "to_byte", VALUEFUNC(_wrap_Item_to_byte), -1);
+  rb_define_method(SwigClassItem.klass, "to_uint", VALUEFUNC(_wrap_Item_to_uint), -1);
+  rb_define_method(SwigClassItem.klass, "to_long_long", VALUEFUNC(_wrap_Item_to_long_long), -1);
+  rb_define_method(SwigClassItem.klass, "to_bool", VALUEFUNC(_wrap_Item_to_bool), -1);
+  rb_define_method(SwigClassItem.klass, "to_int_pair", VALUEFUNC(_wrap_Item_to_int_pair), -1);
+  rb_define_method(SwigClassItem.klass, "to_string_list", VALUEFUNC(_wrap_Item_to_string_list), -1);
+  rb_define_method(SwigClassItem.klass, "to_byte_vector_list", VALUEFUNC(_wrap_Item_to_byte_vector_list), -1);
+  rb_define_method(SwigClassItem.klass, "to_cover_art_list", VALUEFUNC(_wrap_Item_to_cover_art_list), -1);
+  rb_define_method(SwigClassItem.klass, "valid?", VALUEFUNC(_wrap_Item_validq___), -1);
+  rb_define_method(SwigClassItem.klass, "type", VALUEFUNC(_wrap_Item_type), -1);
+  rb_define_method(SwigClassItem.klass, "==", VALUEFUNC(_wrap_Item___eq__), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_bool", VALUEFUNC(_wrap_Item_from_bool), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_byte", VALUEFUNC(_wrap_Item_from_byte), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_uint", VALUEFUNC(_wrap_Item_from_uint), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_int", VALUEFUNC(_wrap_Item_from_int), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_long_long", VALUEFUNC(_wrap_Item_from_long_long), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_string_list", VALUEFUNC(_wrap_Item_from_string_list), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_cover_art_list", VALUEFUNC(_wrap_Item_from_cover_art_list), -1);
+  rb_define_singleton_method(SwigClassItem.klass, "from_byte_vector_list", VALUEFUNC(_wrap_Item_from_byte_vector_list), -1);
+  SwigClassItem.mark = 0;
+  SwigClassItem.destroy = (void (*)(void *)) free_TagLib_MP4_Item;
+  SwigClassItem.trackObjects = 1;
+  
+  SwigClassItemMap.klass = rb_define_class_under(mMP4, "ItemMap", rb_cObject);
+  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, (void *) &SwigClassItemMap);
+  rb_define_alloc_func(SwigClassItemMap.klass, _wrap_ItemMap_allocate);
+  rb_define_method(SwigClassItemMap.klass, "initialize", VALUEFUNC(_wrap_new_ItemMap), -1);
+  rb_define_method(SwigClassItemMap.klass, "cbegin", VALUEFUNC(_wrap_ItemMap_cbegin), -1);
+  rb_define_method(SwigClassItemMap.klass, "cend", VALUEFUNC(_wrap_ItemMap_cend), -1);
+  rb_define_method(SwigClassItemMap.klass, "size", VALUEFUNC(_wrap_ItemMap_size), -1);
+  rb_define_method(SwigClassItemMap.klass, "empty?", VALUEFUNC(_wrap_ItemMap_emptyq___), -1);
+  rb_define_method(SwigClassItemMap.klass, "contains", VALUEFUNC(_wrap_ItemMap_contains), -1);
+  rb_define_alias(SwigClassItemMap.klass, "include?", "contains");
+  rb_define_alias(SwigClassItemMap.klass, "has_key?", "contains");
+  rb_define_method(SwigClassItemMap.klass, "value", VALUEFUNC(_wrap_ItemMap_value), -1);
+  rb_define_method(SwigClassItemMap.klass, "swap", VALUEFUNC(_wrap_ItemMap_swap), -1);
+  rb_define_method(SwigClassItemMap.klass, "==", VALUEFUNC(_wrap_ItemMap___eq__), -1);
+  rb_define_method(SwigClassItemMap.klass, "to_a", VALUEFUNC(_wrap_ItemMap_to_a), -1);
+  rb_define_method(SwigClassItemMap.klass, "to_h", VALUEFUNC(_wrap_ItemMap_to_h), -1);
+  rb_define_method(SwigClassItemMap.klass, "fetch", VALUEFUNC(_wrap_ItemMap_fetch), -1);
+  rb_define_method(SwigClassItemMap.klass, "_clear", VALUEFUNC(_wrap_ItemMap__clear), -1);
+  rb_define_method(SwigClassItemMap.klass, "erase", VALUEFUNC(_wrap_ItemMap_erase), -1);
+  rb_define_method(SwigClassItemMap.klass, "_insert", VALUEFUNC(_wrap_ItemMap__insert), -1);
+  SwigClassItemMap.mark = 0;
+  SwigClassItemMap.destroy = (void (*)(void *)) free_TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg_;
+  SwigClassItemMap.trackObjects = 1;
   
   SwigClassTag.klass = rb_define_class_under(mMP4, "Tag", ((swig_class *) SWIGTYPE_p_TagLib__Tag->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__Tag, (void *) &SwigClassTag);
@@ -5637,83 +6342,28 @@ SWIGEXPORT void Init_taglib_mp4(void) {
   rb_define_method(SwigClassTag.klass, "item_map", VALUEFUNC(_wrap_Tag_item_map), -1);
   rb_define_method(SwigClassTag.klass, "[]", VALUEFUNC(_wrap_Tag___getitem__), -1);
   rb_define_method(SwigClassTag.klass, "contains", VALUEFUNC(_wrap_Tag_contains), -1);
+  rb_define_method(SwigClassTag.klass, "strip", VALUEFUNC(_wrap_Tag_strip), -1);
   rb_define_method(SwigClassTag.klass, "[]=", VALUEFUNC(_wrap_Tag___setitem__), -1);
   rb_define_method(SwigClassTag.klass, "remove_item", VALUEFUNC(_wrap_Tag_remove_item), -1);
   SwigClassTag.mark = 0;
   SwigClassTag.destroy = (void (*)(void *)) free_TagLib_MP4_Tag;
   SwigClassTag.trackObjects = 1;
   
-  SwigClassCoverArt.klass = rb_define_class_under(mMP4, "CoverArt", rb_cObject);
-  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__CoverArt, (void *) &SwigClassCoverArt);
-  rb_define_alloc_func(SwigClassCoverArt.klass, _wrap_CoverArt_allocate);
-  rb_define_method(SwigClassCoverArt.klass, "initialize", VALUEFUNC(_wrap_new_CoverArt), -1);
-  rb_define_const(SwigClassCoverArt.klass, "JPEG", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::JPEG)));
-  rb_define_const(SwigClassCoverArt.klass, "PNG", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::PNG)));
-  rb_define_const(SwigClassCoverArt.klass, "BMP", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::BMP)));
-  rb_define_const(SwigClassCoverArt.klass, "GIF", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::GIF)));
-  rb_define_const(SwigClassCoverArt.klass, "Unknown", SWIG_From_int(static_cast< int >(TagLib::MP4::CoverArt::Unknown)));
-  rb_define_method(SwigClassCoverArt.klass, "format", VALUEFUNC(_wrap_CoverArt_format), -1);
-  rb_define_method(SwigClassCoverArt.klass, "data", VALUEFUNC(_wrap_CoverArt_data), -1);
-  SwigClassCoverArt.mark = 0;
-  SwigClassCoverArt.destroy = (void (*)(void *)) free_TagLib_MP4_CoverArt;
-  SwigClassCoverArt.trackObjects = 1;
-  
-  SwigClassItem.klass = rb_define_class_under(mMP4, "Item", rb_cObject);
-  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__Item, (void *) &SwigClassItem);
-  rb_define_alloc_func(SwigClassItem.klass, _wrap_Item_allocate);
-  rb_define_method(SwigClassItem.klass, "initialize", VALUEFUNC(_wrap_new_Item), -1);
-  rb_define_method(SwigClassItem.klass, "to_int", VALUEFUNC(_wrap_Item_to_int), -1);
-  rb_define_method(SwigClassItem.klass, "to_byte", VALUEFUNC(_wrap_Item_to_byte), -1);
-  rb_define_method(SwigClassItem.klass, "to_uint", VALUEFUNC(_wrap_Item_to_uint), -1);
-  rb_define_method(SwigClassItem.klass, "to_long_long", VALUEFUNC(_wrap_Item_to_long_long), -1);
-  rb_define_method(SwigClassItem.klass, "to_bool", VALUEFUNC(_wrap_Item_to_bool), -1);
-  rb_define_method(SwigClassItem.klass, "to_int_pair", VALUEFUNC(_wrap_Item_to_int_pair), -1);
-  rb_define_method(SwigClassItem.klass, "to_string_list", VALUEFUNC(_wrap_Item_to_string_list), -1);
-  rb_define_method(SwigClassItem.klass, "to_byte_vector_list", VALUEFUNC(_wrap_Item_to_byte_vector_list), -1);
-  rb_define_method(SwigClassItem.klass, "to_cover_art_list", VALUEFUNC(_wrap_Item_to_cover_art_list), -1);
-  rb_define_method(SwigClassItem.klass, "valid?", VALUEFUNC(_wrap_Item_validq___), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_bool", VALUEFUNC(_wrap_Item_from_bool), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_byte", VALUEFUNC(_wrap_Item_from_byte), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_uint", VALUEFUNC(_wrap_Item_from_uint), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_int", VALUEFUNC(_wrap_Item_from_int), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_long_long", VALUEFUNC(_wrap_Item_from_long_long), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_string_list", VALUEFUNC(_wrap_Item_from_string_list), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_cover_art_list", VALUEFUNC(_wrap_Item_from_cover_art_list), -1);
-  rb_define_singleton_method(SwigClassItem.klass, "from_byte_vector_list", VALUEFUNC(_wrap_Item_from_byte_vector_list), -1);
-  SwigClassItem.mark = 0;
-  SwigClassItem.destroy = (void (*)(void *)) free_TagLib_MP4_Item;
-  SwigClassItem.trackObjects = 1;
-  
   SwigClassFile.klass = rb_define_class_under(mMP4, "File", ((swig_class *) SWIGTYPE_p_TagLib__File->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__MP4__File, (void *) &SwigClassFile);
   rb_define_alloc_func(SwigClassFile.klass, _wrap_File_allocate);
   rb_define_method(SwigClassFile.klass, "initialize", VALUEFUNC(_wrap_new_File), -1);
+  rb_define_const(SwigClassFile.klass, "NoTags", SWIG_From_int(static_cast< int >(TagLib::MP4::File::NoTags)));
+  rb_define_const(SwigClassFile.klass, "MP4", SWIG_From_int(static_cast< int >(TagLib::MP4::File::MP4)));
+  rb_define_const(SwigClassFile.klass, "AllTags", SWIG_From_int(static_cast< int >(TagLib::MP4::File::AllTags)));
   rb_define_method(SwigClassFile.klass, "tag", VALUEFUNC(_wrap_File_tag), -1);
   rb_define_method(SwigClassFile.klass, "audio_properties", VALUEFUNC(_wrap_File_audio_properties), -1);
   rb_define_method(SwigClassFile.klass, "save", VALUEFUNC(_wrap_File_save), -1);
+  rb_define_method(SwigClassFile.klass, "strip", VALUEFUNC(_wrap_File_strip), -1);
   rb_define_method(SwigClassFile.klass, "mp4_tag?", VALUEFUNC(_wrap_File_mp4_tagq___), -1);
   rb_define_method(SwigClassFile.klass, "close", VALUEFUNC(_wrap_File_close), -1);
   SwigClassFile.mark = 0;
   SwigClassFile.destroy = (void (*)(void *)) free_taglib_mp4_file;
   SwigClassFile.trackObjects = 1;
-  
-  SwigClassItemMap.klass = rb_define_class_under(mMP4, "ItemMap", rb_cObject);
-  SWIG_TypeClientData(SWIGTYPE_p_TagLib__MapT_TagLib__String_TagLib__MP4__Item_t, (void *) &SwigClassItemMap);
-  rb_define_alloc_func(SwigClassItemMap.klass, _wrap_ItemMap_allocate);
-  rb_define_method(SwigClassItemMap.klass, "initialize", VALUEFUNC(_wrap_new_ItemMap), -1);
-  rb_define_method(SwigClassItemMap.klass, "size", VALUEFUNC(_wrap_ItemMap_size), -1);
-  rb_define_method(SwigClassItemMap.klass, "empty?", VALUEFUNC(_wrap_ItemMap_emptyq___), -1);
-  rb_define_method(SwigClassItemMap.klass, "contains", VALUEFUNC(_wrap_ItemMap_contains), -1);
-  rb_define_alias(SwigClassItemMap.klass, "include?", "contains");
-  rb_define_alias(SwigClassItemMap.klass, "has_key?", "contains");
-  rb_define_method(SwigClassItemMap.klass, "to_a", VALUEFUNC(_wrap_ItemMap_to_a), -1);
-  rb_define_method(SwigClassItemMap.klass, "to_h", VALUEFUNC(_wrap_ItemMap_to_h), -1);
-  rb_define_method(SwigClassItemMap.klass, "fetch", VALUEFUNC(_wrap_ItemMap_fetch), -1);
-  rb_define_method(SwigClassItemMap.klass, "_clear", VALUEFUNC(_wrap_ItemMap__clear), -1);
-  rb_define_method(SwigClassItemMap.klass, "erase", VALUEFUNC(_wrap_ItemMap_erase), -1);
-  rb_define_method(SwigClassItemMap.klass, "_insert", VALUEFUNC(_wrap_ItemMap__insert), -1);
-  SwigClassItemMap.mark = 0;
-  SwigClassItemMap.destroy = (void (*)(void *)) free_TagLib_Map_Sl_TagLib_String_Sc_TagLib_MP4_Item_Sg_;
-  SwigClassItemMap.trackObjects = 1;
 }
 

--- a/ext/taglib_mpeg/taglib_mpeg.i
+++ b/ext/taglib_mpeg/taglib_mpeg.i
@@ -6,6 +6,8 @@
 #include <taglib/mpegproperties.h>
 #include <taglib/mpegfile.h>
 #include <taglib/id3v2tag.h>
+#include <taglib/tpicturetype.h>
+using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_mpeg/taglib_mpeg.i
+++ b/ext/taglib_mpeg/taglib_mpeg.i
@@ -6,8 +6,6 @@
 #include <taglib/mpegproperties.h>
 #include <taglib/mpegfile.h>
 #include <taglib/id3v2tag.h>
-#include <taglib/tpicturetype.h>
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"
@@ -16,6 +14,7 @@ using namespace TagLib;
 %ignore TagLib::MPEG::Header::operator=;
 %include <taglib/xingheader.h>
 
+%include <taglib/id3v2.h>
 %include <taglib/mpegheader.h>
 
 %ignore TagLib::MPEG::length; // Deprecated.
@@ -32,6 +31,10 @@ using namespace TagLib;
 %ignore TagLib::MPEG::File::File(IOStream *, ID3v2::FrameFactory *, bool, Properties::ReadStyle);
 %ignore TagLib::MPEG::File::File(IOStream *, ID3v2::FrameFactory *, bool);
 %ignore TagLib::MPEG::File::File(IOStream *, ID3v2::FrameFactory *);
+%ignore TagLib::MPEG::File::File(IOStream *, bool, Properties::ReadStyle, ID3v2::FrameFactory *);
+%ignore TagLib::MPEG::File::File(IOStream *, bool, Properties::ReadStyle);
+%ignore TagLib::MPEG::File::File(IOStream *, bool);
+%ignore TagLib::MPEG::File::File(IOStream *);
 %ignore TagLib::MPEG::File::isSupported(IOStream *);
 %rename("id3v1_tag?") TagLib::MPEG::File::hasID3v1Tag;
 %rename("id3v2_tag?") TagLib::MPEG::File::hasID3v2Tag;

--- a/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
+++ b/ext/taglib_mpeg/taglib_mpeg_wrap.cxx
@@ -1865,12 +1865,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__MPEG__XingHeader swig_types[9]
 #define SWIGTYPE_p_TagLib__Tag swig_types[10]
 #define SWIGTYPE_p_char swig_types[11]
-#define SWIGTYPE_p_unsigned_char swig_types[12]
-#define SWIGTYPE_p_unsigned_int swig_types[13]
-#define SWIGTYPE_p_unsigned_long swig_types[14]
-#define SWIGTYPE_p_wchar_t swig_types[15]
-static swig_type_info *swig_types[17];
-static swig_module_info swig_module = {swig_types, 16, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[12]
+#define SWIGTYPE_p_unsigned_char swig_types[13]
+#define SWIGTYPE_p_unsigned_int swig_types[14]
+#define SWIGTYPE_p_unsigned_long swig_types[15]
+#define SWIGTYPE_p_wchar_t swig_types[16]
+static swig_type_info *swig_types[18];
+static swig_module_info swig_module = {swig_types, 17, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1966,34 +1967,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2082,6 +2075,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 #include <limits.h>
@@ -2180,6 +2180,43 @@ SWIG_ruby_failed(VALUE SWIGUNUSEDPARM(arg1), VALUE SWIGUNUSEDPARM(arg2))
 {
   return Qnil;
 } 
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+/*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+SWIGINTERN VALUE SWIG_AUX_NUM2LL(VALUE arg)
+{
+  VALUE *args = (VALUE *)arg;
+  VALUE obj = args[0];
+  VALUE type = TYPE(obj);
+  long long *res = (long long *)(args[1]);
+  *res = type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj);
+  return obj;
+}
+/*@SWIG@*/
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (VALUE obj, long long *val)
+{
+  VALUE type = TYPE(obj);
+  if ((type == T_FIXNUM) || (type == T_BIGNUM)) {
+    long long v;
+    VALUE a[2];
+    a[0] = obj;
+    a[1] = (VALUE)(&v);
+    if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2LL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (val) *val = v;
+      return SWIG_OK;
+    }
+  }
+  return SWIG_TypeError;
+}
+#endif
 
 
 /*@SWIG:/swig/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
@@ -2433,70 +2470,16 @@ fail:
 }
 
 
-SWIGINTERN VALUE
-_wrap_XingHeader_xing_header_offset(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::Header::Version arg1 ;
-  TagLib::MPEG::Header::ChannelMode arg2 ;
-  int val1 ;
-  int ecode1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  ecode1 = SWIG_AsVal_int(argv[0], &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "TagLib::MPEG::Header::Version","TagLib::MPEG::XingHeader::xingHeaderOffset", 1, argv[0] ));
-  } 
-  arg1 = static_cast< TagLib::MPEG::Header::Version >(val1);
-  ecode2 = SWIG_AsVal_int(argv[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::MPEG::Header::ChannelMode","TagLib::MPEG::XingHeader::xingHeaderOffset", 2, argv[1] ));
-  } 
-  arg2 = static_cast< TagLib::MPEG::Header::ChannelMode >(val2);
-  result = (int)TagLib::MPEG::XingHeader::xingHeaderOffset(arg1,arg2);
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
 static swig_class SwigClassHeader;
 
 SWIGINTERN VALUE
 _wrap_new_Header__SWIG_0(int argc, VALUE *argv, VALUE self) {
-  TagLib::ByteVector *arg1 = 0 ;
-  TagLib::ByteVector tmp1 ;
-  TagLib::MPEG::Header *result = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  {
-    tmp1 = ruby_string_to_taglib_bytevector(argv[0]);
-    arg1 = &tmp1;
-  }
-  result = (TagLib::MPEG::Header *)new TagLib::MPEG::Header((TagLib::ByteVector const &)*arg1);
-  DATA_PTR(self) = result;
-  SWIG_RubyAddTracking(result, self);
-  return self;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_new_Header__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  long arg2 ;
+  TagLib::File *arg1 = (TagLib::File *) 0 ;
+  TagLib::offset_t arg2 ;
   bool arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   bool val3 ;
   int ecode3 = 0 ;
@@ -2505,16 +2488,16 @@ _wrap_new_Header__SWIG_1(int argc, VALUE *argv, VALUE self) {
   if ((argc < 3) || (argc > 3)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
   }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__File, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","Header", 1, argv[0] )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Header", 1, argv[0] )); 
   }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  arg1 = reinterpret_cast< TagLib::File * >(argp1);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Header", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Header", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   ecode3 = SWIG_AsVal_bool(argv[2], &val3);
   if (!SWIG_IsOK(ecode3)) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","Header", 3, argv[2] ));
@@ -2530,28 +2513,28 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_Header__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  long arg2 ;
+_wrap_new_Header__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::File *arg1 = (TagLib::File *) 0 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   TagLib::MPEG::Header *result = 0 ;
   
   if ((argc < 2) || (argc > 2)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_TagLib__File, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","Header", 1, argv[0] )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::File *","Header", 1, argv[0] )); 
   }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[1], &val2);
+  arg1 = reinterpret_cast< TagLib::File * >(argp1);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[1], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","Header", 2, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","Header", 2, argv[1] ));
   } 
-  arg2 = static_cast< long >(val2);
+  arg2 = static_cast< TagLib::offset_t >(val2);
   result = (TagLib::MPEG::Header *)new TagLib::MPEG::Header(arg1,arg2);
   DATA_PTR(self) = result;
   SWIG_RubyAddTracking(result, self);
@@ -2577,7 +2560,7 @@ _wrap_Header_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_Header__SWIG_3(int argc, VALUE *argv, VALUE self) {
+_wrap_new_Header__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::Header *arg1 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2619,40 +2602,32 @@ SWIGINTERN VALUE _wrap_new_Header(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MPEG__Header, SWIG_POINTER_NO_NULL);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_Header__SWIG_3(nargs, args, self);
-    }
-  }
-  if (argc == 1) {
-    int _v = 0;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      return _wrap_new_Header__SWIG_0(nargs, args, self);
+      return _wrap_new_Header__SWIG_2(nargs, args, self);
     }
   }
   if (argc == 2) {
     int _v = 0;
     void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MPEG__File, 0);
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__File, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_Header__SWIG_2(nargs, args, self);
+        return _wrap_new_Header__SWIG_1(nargs, args, self);
       }
     }
   }
   if (argc == 3) {
     int _v = 0;
     void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MPEG__File, 0);
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__File, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_long(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -2661,7 +2636,7 @@ SWIGINTERN VALUE _wrap_new_Header(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_Header__SWIG_1(nargs, args, self);
+          return _wrap_new_Header__SWIG_0(nargs, args, self);
         }
       }
     }
@@ -2669,9 +2644,8 @@ SWIGINTERN VALUE _wrap_new_Header(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Header.new", 
-    "    Header.new(TagLib::ByteVector const &data)\n"
-    "    Header.new(TagLib::MPEG::File *file, long offset, bool checkLength)\n"
-    "    Header.new(TagLib::MPEG::File *file, long offset)\n"
+    "    Header.new(TagLib::File *file, TagLib::offset_t offset, bool checkLength)\n"
+    "    Header.new(TagLib::File *file, TagLib::offset_t offset)\n"
     "    Header.new(TagLib::MPEG::Header const &h)\n");
   
   return Qnil;
@@ -2871,6 +2845,54 @@ _wrap_Header_channel_mode(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< TagLib::MPEG::Header * >(argp1);
   result = (TagLib::MPEG::Header::ChannelMode)((TagLib::MPEG::Header const *)arg1)->channelMode();
   vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Header_channel_configuration(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::Header *arg1 = (TagLib::MPEG::Header *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MPEG::Header::ChannelConfiguration result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__Header, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::Header const *","channelConfiguration", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::Header * >(argp1);
+  result = (TagLib::MPEG::Header::ChannelConfiguration)((TagLib::MPEG::Header const *)arg1)->channelConfiguration();
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Header_is_adts(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::Header *arg1 = (TagLib::MPEG::Header *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__Header, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::Header const *","isADTS", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::Header * >(argp1);
+  result = (bool)((TagLib::MPEG::Header const *)arg1)->isADTS();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
 fail:
   return Qnil;
@@ -3098,30 +3120,6 @@ free_TagLib_MPEG_Properties(void *self) {
 }
 
 SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::Properties *arg1 = (TagLib::MPEG::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::Properties * >(argp1);
-  result = (int)((TagLib::MPEG::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::Properties *arg1 = (TagLib::MPEG::Properties *) 0 ;
   void *argp1 = 0 ;
@@ -3338,6 +3336,54 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_Properties_channel_configuration(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::Properties *arg1 = (TagLib::MPEG::Properties *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::MPEG::Header::ChannelConfiguration result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__Properties, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::Properties const *","channelConfiguration", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::Properties * >(argp1);
+  result = (TagLib::MPEG::Header::ChannelConfiguration)((TagLib::MPEG::Properties const *)arg1)->channelConfiguration();
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Properties_is_adts(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::Properties *arg1 = (TagLib::MPEG::Properties *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__Properties, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::Properties const *","isADTS", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::Properties * >(argp1);
+  result = (bool)((TagLib::MPEG::Properties const *)arg1)->isADTS();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_Properties_copyrightedq___(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::Properties *arg1 = (TagLib::MPEG::Properties *) 0 ;
   void *argp1 = 0 ;
@@ -3392,6 +3438,53 @@ _wrap_new_File__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   TagLib::MPEG::Properties::ReadStyle arg3 ;
+  TagLib::ID3v2::FrameFactory *arg4 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  TagLib::MPEG::File *result = 0 ;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  {
+    arg1 = ruby_string_to_taglib_filename(argv[0]);
+    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
+      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
+    }
+  }
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","File", 2, argv[1] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::MPEG::Properties::ReadStyle","File", 3, argv[2] ));
+  } 
+  arg3 = static_cast< TagLib::MPEG::Properties::ReadStyle >(val3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory *","File", 4, argv[3] )); 
+  }
+  arg4 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp4);
+  result = (TagLib::MPEG::File *)new TagLib::MPEG::File(arg1,arg2,arg3,arg4);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::FileName arg1 ;
+  bool arg2 ;
+  TagLib::MPEG::Properties::ReadStyle arg3 ;
   bool val2 ;
   int ecode2 = 0 ;
   int val3 ;
@@ -3427,7 +3520,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   bool val2 ;
@@ -3458,7 +3551,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::MPEG::File *result = 0 ;
   
@@ -3481,7 +3574,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_4(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   bool arg3 ;
@@ -3528,7 +3621,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_4(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_5(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   bool arg3 ;
@@ -3582,7 +3675,7 @@ _wrap_File_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_5(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_6(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
   void *argp2 = 0 ;
@@ -3627,7 +3720,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_File__SWIG_2(nargs, args, self);
+      return _wrap_new_File__SWIG_3(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -3639,7 +3732,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_new_File__SWIG_5(nargs, args, self);
+        return _wrap_new_File__SWIG_6(nargs, args, self);
       }
     }
   }
@@ -3653,7 +3746,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_File__SWIG_1(nargs, args, self);
+        return _wrap_new_File__SWIG_2(nargs, args, self);
       }
     }
   }
@@ -3671,7 +3764,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_4(nargs, args, self);
+          return _wrap_new_File__SWIG_5(nargs, args, self);
         }
       }
     }
@@ -3691,7 +3784,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_0(nargs, args, self);
+          return _wrap_new_File__SWIG_1(nargs, args, self);
         }
       }
     }
@@ -3715,7 +3808,32 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
             _v = SWIG_CheckState(res);
           }
           if (_v) {
-            return _wrap_new_File__SWIG_3(nargs, args, self);
+            return _wrap_new_File__SWIG_4(nargs, args, self);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_new_File__SWIG_0(nargs, args, self);
           }
         }
       }
@@ -3724,10 +3842,11 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 4, "File.new", 
-    "    File.new(TagLib::FileName file, bool readProperties, TagLib::MPEG::Properties::ReadStyle propertiesStyle)\n"
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::MPEG::Properties::ReadStyle readStyle, TagLib::ID3v2::FrameFactory *frameFactory)\n"
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::MPEG::Properties::ReadStyle readStyle)\n"
     "    File.new(TagLib::FileName file, bool readProperties)\n"
     "    File.new(TagLib::FileName file)\n"
-    "    File.new(TagLib::FileName file, TagLib::ID3v2::FrameFactory *frameFactory, bool readProperties, TagLib::MPEG::Properties::ReadStyle propertiesStyle)\n"
+    "    File.new(TagLib::FileName file, TagLib::ID3v2::FrameFactory *frameFactory, bool readProperties, TagLib::MPEG::Properties::ReadStyle readStyle)\n"
     "    File.new(TagLib::FileName file, TagLib::ID3v2::FrameFactory *frameFactory, bool readProperties)\n"
     "    File.new(TagLib::FileName file, TagLib::ID3v2::FrameFactory *frameFactory)\n");
   
@@ -3811,6 +3930,150 @@ SWIGINTERN VALUE
 _wrap_File_save__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
   int arg2 ;
+  TagLib::File::StripTags arg3 ;
+  TagLib::ID3v2::Version arg4 ;
+  TagLib::File::DuplicateTags arg5 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  int val5 ;
+  int ecode5 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::StripTags","save", 3, argv[1] ));
+  } 
+  arg3 = static_cast< TagLib::File::StripTags >(val3);
+  ecode4 = SWIG_AsVal_int(argv[2], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "TagLib::ID3v2::Version","save", 4, argv[2] ));
+  } 
+  arg4 = static_cast< TagLib::ID3v2::Version >(val4);
+  ecode5 = SWIG_AsVal_int(argv[3], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), Ruby_Format_TypeError( "", "TagLib::File::DuplicateTags","save", 5, argv[3] ));
+  } 
+  arg5 = static_cast< TagLib::File::DuplicateTags >(val5);
+  result = (bool)(arg1)->save(arg2,arg3,arg4,arg5);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_save__SWIG_2(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
+  int arg2 ;
+  TagLib::File::StripTags arg3 ;
+  TagLib::ID3v2::Version arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 3) || (argc > 3)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::StripTags","save", 3, argv[1] ));
+  } 
+  arg3 = static_cast< TagLib::File::StripTags >(val3);
+  ecode4 = SWIG_AsVal_int(argv[2], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "TagLib::ID3v2::Version","save", 4, argv[2] ));
+  } 
+  arg4 = static_cast< TagLib::ID3v2::Version >(val4);
+  result = (bool)(arg1)->save(arg2,arg3,arg4);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_save__SWIG_3(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
+  int arg2 ;
+  TagLib::File::StripTags arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::StripTags","save", 3, argv[1] ));
+  } 
+  arg3 = static_cast< TagLib::File::StripTags >(val3);
+  result = (bool)(arg1)->save(arg2,arg3);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_save__SWIG_4(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
+  int arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   int val2 ;
@@ -3832,150 +4095,6 @@ _wrap_File_save__SWIG_1(int argc, VALUE *argv, VALUE self) {
   } 
   arg2 = static_cast< int >(val2);
   result = (bool)(arg1)->save(arg2);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_save__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  int arg2 ;
-  bool arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  bool val3 ;
-  int ecode3 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 2) || (argc > 2)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
-  } 
-  arg2 = static_cast< int >(val2);
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","save", 3, argv[1] ));
-  } 
-  arg3 = static_cast< bool >(val3);
-  result = (bool)(arg1)->save(arg2,arg3);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_save__SWIG_3(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  int arg2 ;
-  bool arg3 ;
-  int arg4 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  bool val3 ;
-  int ecode3 = 0 ;
-  int val4 ;
-  int ecode4 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 3) || (argc > 3)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
-  } 
-  arg2 = static_cast< int >(val2);
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","save", 3, argv[1] ));
-  } 
-  arg3 = static_cast< bool >(val3);
-  ecode4 = SWIG_AsVal_int(argv[2], &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "int","save", 4, argv[2] ));
-  } 
-  arg4 = static_cast< int >(val4);
-  result = (bool)(arg1)->save(arg2,arg3,arg4);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_save__SWIG_4(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  int arg2 ;
-  bool arg3 ;
-  int arg4 ;
-  bool arg5 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  bool val3 ;
-  int ecode3 = 0 ;
-  int val4 ;
-  int ecode4 = 0 ;
-  bool val5 ;
-  int ecode5 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 4) || (argc > 4)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","save", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","save", 2, argv[0] ));
-  } 
-  arg2 = static_cast< int >(val2);
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","save", 3, argv[1] ));
-  } 
-  arg3 = static_cast< bool >(val3);
-  ecode4 = SWIG_AsVal_int(argv[2], &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "int","save", 4, argv[2] ));
-  } 
-  arg4 = static_cast< int >(val4);
-  ecode5 = SWIG_AsVal_bool(argv[3], &val5);
-  if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), Ruby_Format_TypeError( "", "bool","save", 5, argv[3] ));
-  } 
-  arg5 = static_cast< bool >(val5);
-  result = (bool)(arg1)->save(arg2,arg3,arg4,arg5);
   vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
 fail:
@@ -4014,7 +4133,7 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_File_save__SWIG_1(nargs, args, self);
+        return _wrap_File_save__SWIG_4(nargs, args, self);
       }
     }
   }
@@ -4030,11 +4149,11 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
+          int res = SWIG_AsVal_int(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_File_save__SWIG_2(nargs, args, self);
+          return _wrap_File_save__SWIG_3(nargs, args, self);
         }
       }
     }
@@ -4051,7 +4170,7 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
+          int res = SWIG_AsVal_int(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -4060,7 +4179,7 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
             _v = SWIG_CheckState(res);
           }
           if (_v) {
-            return _wrap_File_save__SWIG_3(nargs, args, self);
+            return _wrap_File_save__SWIG_2(nargs, args, self);
           }
         }
       }
@@ -4078,7 +4197,7 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
+          int res = SWIG_AsVal_int(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -4088,11 +4207,11 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
           }
           if (_v) {
             {
-              int res = SWIG_AsVal_bool(argv[4], NULL);
+              int res = SWIG_AsVal_int(argv[4], NULL);
               _v = SWIG_CheckState(res);
             }
             if (_v) {
-              return _wrap_File_save__SWIG_4(nargs, args, self);
+              return _wrap_File_save__SWIG_1(nargs, args, self);
             }
           }
         }
@@ -4103,10 +4222,10 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 6, "File.save", 
     "    bool File.save()\n"
-    "    bool File.save(int tags)\n"
-    "    bool File.save(int tags, bool stripOthers)\n"
-    "    bool File.save(int tags, bool stripOthers, int id3v2Version)\n"
-    "    bool File.save(int tags, bool stripOthers, int id3v2Version, bool duplicateTags)\n");
+    "    bool File.save(int tags, TagLib::File::StripTags strip, TagLib::ID3v2::Version version, TagLib::File::DuplicateTags duplicate)\n"
+    "    bool File.save(int tags, TagLib::File::StripTags strip, TagLib::ID3v2::Version version)\n"
+    "    bool File.save(int tags, TagLib::File::StripTags strip)\n"
+    "    bool File.save(int tags)\n");
   
   return Qnil;
 }
@@ -4419,62 +4538,6 @@ SWIGINTERN VALUE
 _wrap_File_strip__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
   int arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","strip", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_int(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","strip", 2, argv[0] ));
-  } 
-  arg2 = static_cast< int >(val2);
-  result = (bool)(arg1)->strip(arg2);
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_strip__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","strip", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  result = (bool)(arg1)->strip();
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_strip__SWIG_2(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  int arg2 ;
   bool arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4511,6 +4574,62 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_File_strip__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","strip", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","strip", 2, argv[0] ));
+  } 
+  arg2 = static_cast< int >(val2);
+  result = (bool)(arg1)->strip(arg2);
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_File_strip__SWIG_2(int argc, VALUE *argv, VALUE self) {
+  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","strip", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
+  result = (bool)(arg1)->strip();
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
   int argc;
   VALUE argv[4];
@@ -4528,7 +4647,7 @@ SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__MPEG__File, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_File_strip__SWIG_1(nargs, args, self);
+      return _wrap_File_strip__SWIG_2(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -4542,7 +4661,7 @@ SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_File_strip__SWIG_0(nargs, args, self);
+        return _wrap_File_strip__SWIG_1(nargs, args, self);
       }
     }
   }
@@ -4562,7 +4681,7 @@ SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_File_strip__SWIG_2(nargs, args, self);
+          return _wrap_File_strip__SWIG_0(nargs, args, self);
         }
       }
     }
@@ -4570,39 +4689,10 @@ SWIGINTERN VALUE _wrap_File_strip(int nargs, VALUE *args, VALUE self) {
   
 fail:
   Ruby_Format_OverloadedError( argc, 4, "File.strip", 
+    "    bool File.strip(int tags, bool freeMemory)\n"
     "    bool File.strip(int tags)\n"
-    "    bool File.strip()\n"
-    "    bool File.strip(int tags, bool freeMemory)\n");
+    "    bool File.strip()\n");
   
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_File_set_id3v2_frame_factory(int argc, VALUE *argv, VALUE self) {
-  TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  TagLib::ID3v2::FrameFactory *arg2 = (TagLib::ID3v2::FrameFactory *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  
-  if ((argc < 1) || (argc > 1)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__MPEG__File, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","setID3v2FrameFactory", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  res2 = SWIG_ConvertPtr(argv[0], &argp2,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory const *","setID3v2FrameFactory", 2, argv[0] )); 
-  }
-  arg2 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp2);
-  (arg1)->setID3v2FrameFactory((TagLib::ID3v2::FrameFactory const *)arg2);
-  return Qnil;
-fail:
   return Qnil;
 }
 
@@ -4612,7 +4702,7 @@ _wrap_File_first_frame_offset(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -4623,8 +4713,10 @@ _wrap_File_first_frame_offset(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","firstFrameOffset", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  result = (long)(arg1)->firstFrameOffset();
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->firstFrameOffset();
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -4634,12 +4726,12 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_next_frame_offset(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -4650,13 +4742,15 @@ _wrap_File_next_frame_offset(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","nextFrameOffset", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","nextFrameOffset", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","nextFrameOffset", 2, argv[0] ));
   } 
-  arg2 = static_cast< long >(val2);
-  result = (long)(arg1)->nextFrameOffset(arg2);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  arg2 = static_cast< TagLib::offset_t >(val2);
+  result = (TagLib::offset_t)(arg1)->nextFrameOffset(arg2);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -4666,12 +4760,12 @@ fail:
 SWIGINTERN VALUE
 _wrap_File_previous_frame_offset(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
-  long arg2 ;
+  TagLib::offset_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -4682,13 +4776,15 @@ _wrap_File_previous_frame_offset(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","previousFrameOffset", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  ecode2 = SWIG_AsVal_long(argv[0], &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "long","previousFrameOffset", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::offset_t","previousFrameOffset", 2, argv[0] ));
   } 
-  arg2 = static_cast< long >(val2);
-  result = (long)(arg1)->previousFrameOffset(arg2);
-  vresult = SWIG_From_long(static_cast< long >(result));
+  arg2 = static_cast< TagLib::offset_t >(val2);
+  result = (TagLib::offset_t)(arg1)->previousFrameOffset(arg2);
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -4700,7 +4796,7 @@ _wrap_File_last_frame_offset(int argc, VALUE *argv, VALUE self) {
   TagLib::MPEG::File *arg1 = (TagLib::MPEG::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  long result;
+  TagLib::offset_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -4711,8 +4807,10 @@ _wrap_File_last_frame_offset(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::MPEG::File *","lastFrameOffset", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::MPEG::File * >(argp1);
-  result = (long)(arg1)->lastFrameOffset();
-  vresult = SWIG_From_long(static_cast< long >(result));
+  result = (TagLib::offset_t)(arg1)->lastFrameOffset();
+  {
+    vresult = taglib_offset_t_to_ruby_int(result);
+  }
   return vresult;
 fail:
   return Qnil;
@@ -4833,6 +4931,7 @@ static swig_type_info _swigt__p_TagLib__MPEG__Properties = {"_p_TagLib__MPEG__Pr
 static swig_type_info _swigt__p_TagLib__MPEG__XingHeader = {"_p_TagLib__MPEG__XingHeader", "TagLib::MPEG::XingHeader *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -4851,6 +4950,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__MPEG__XingHeader,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -4869,6 +4969,7 @@ static swig_cast_info _swigc__p_TagLib__MPEG__Properties[] = {  {&_swigt__p_TagL
 static swig_cast_info _swigc__p_TagLib__MPEG__XingHeader[] = {  {&_swigt__p_TagLib__MPEG__XingHeader, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -4887,6 +4988,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__MPEG__XingHeader,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -5162,10 +5264,11 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   rb_define_method(SwigClassXingHeader.klass, "total_frames", VALUEFUNC(_wrap_XingHeader_total_frames), -1);
   rb_define_method(SwigClassXingHeader.klass, "total_size", VALUEFUNC(_wrap_XingHeader_total_size), -1);
   rb_define_method(SwigClassXingHeader.klass, "type", VALUEFUNC(_wrap_XingHeader_type), -1);
-  rb_define_singleton_method(SwigClassXingHeader.klass, "xing_header_offset", VALUEFUNC(_wrap_XingHeader_xing_header_offset), -1);
   SwigClassXingHeader.mark = 0;
   SwigClassXingHeader.destroy = (void (*)(void *)) free_TagLib_MPEG_XingHeader;
   SwigClassXingHeader.trackObjects = 1;
+  rb_define_const(mMPEG, "V3", SWIG_From_int(static_cast< int >(TagLib::ID3v2::v3)));
+  rb_define_const(mMPEG, "V4", SWIG_From_int(static_cast< int >(TagLib::ID3v2::v4)));
   
   SwigClassHeader.klass = rb_define_class_under(mMPEG, "Header", rb_cObject);
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__MPEG__Header, (void *) &SwigClassHeader);
@@ -5175,6 +5278,7 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   rb_define_const(SwigClassHeader.klass, "Version1", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::Version1)));
   rb_define_const(SwigClassHeader.klass, "Version2", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::Version2)));
   rb_define_const(SwigClassHeader.klass, "Version2_5", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::Version2_5)));
+  rb_define_const(SwigClassHeader.klass, "Version4", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::Version4)));
   rb_define_method(SwigClassHeader.klass, "version", VALUEFUNC(_wrap_Header_version), -1);
   rb_define_method(SwigClassHeader.klass, "layer", VALUEFUNC(_wrap_Header_layer), -1);
   rb_define_method(SwigClassHeader.klass, "protection_enabled", VALUEFUNC(_wrap_Header_protection_enabled), -1);
@@ -5186,6 +5290,16 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   rb_define_const(SwigClassHeader.klass, "DualChannel", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::DualChannel)));
   rb_define_const(SwigClassHeader.klass, "SingleChannel", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::SingleChannel)));
   rb_define_method(SwigClassHeader.klass, "channel_mode", VALUEFUNC(_wrap_Header_channel_mode), -1);
+  rb_define_const(SwigClassHeader.klass, "Custom", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::Custom)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenter", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenter)));
+  rb_define_const(SwigClassHeader.klass, "FrontLeftRight", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontLeftRight)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenterLeftRight", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenterLeftRight)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenterLeftRightBackCenter", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenterLeftRightBackCenter)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenterLeftRightBackLeftRight", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenterLeftRightBackLeftRight)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenterLeftRightBackLeftRightLFE", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenterLeftRightBackLeftRightLFE)));
+  rb_define_const(SwigClassHeader.klass, "FrontCenterLeftRightSideLeftRightBackLeftRightLFE", SWIG_From_int(static_cast< int >(TagLib::MPEG::Header::FrontCenterLeftRightSideLeftRightBackLeftRightLFE)));
+  rb_define_method(SwigClassHeader.klass, "channel_configuration", VALUEFUNC(_wrap_Header_channel_configuration), -1);
+  rb_define_method(SwigClassHeader.klass, "is_adts", VALUEFUNC(_wrap_Header_is_adts), -1);
   rb_define_method(SwigClassHeader.klass, "copyrighted?", VALUEFUNC(_wrap_Header_copyrightedq___), -1);
   rb_define_method(SwigClassHeader.klass, "original?", VALUEFUNC(_wrap_Header_originalq___), -1);
   rb_define_method(SwigClassHeader.klass, "frame_length", VALUEFUNC(_wrap_Header_frame_length), -1);
@@ -5198,7 +5312,6 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__MPEG__Properties, (void *) &SwigClassProperties);
   rb_define_alloc_func(SwigClassProperties.klass, _wrap_Properties_allocate);
   rb_define_method(SwigClassProperties.klass, "initialize", VALUEFUNC(_wrap_new_Properties), -1);
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);
@@ -5208,6 +5321,8 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   rb_define_method(SwigClassProperties.klass, "layer", VALUEFUNC(_wrap_Properties_layer), -1);
   rb_define_method(SwigClassProperties.klass, "protection_enabled", VALUEFUNC(_wrap_Properties_protection_enabled), -1);
   rb_define_method(SwigClassProperties.klass, "channel_mode", VALUEFUNC(_wrap_Properties_channel_mode), -1);
+  rb_define_method(SwigClassProperties.klass, "channel_configuration", VALUEFUNC(_wrap_Properties_channel_configuration), -1);
+  rb_define_method(SwigClassProperties.klass, "is_adts", VALUEFUNC(_wrap_Properties_is_adts), -1);
   rb_define_method(SwigClassProperties.klass, "copyrighted?", VALUEFUNC(_wrap_Properties_copyrightedq___), -1);
   rb_define_method(SwigClassProperties.klass, "original?", VALUEFUNC(_wrap_Properties_originalq___), -1);
   SwigClassProperties.mark = 0;
@@ -5230,7 +5345,6 @@ SWIGEXPORT void Init_taglib_mpeg(void) {
   rb_define_method(SwigClassFile.klass, "id3v1_tag", VALUEFUNC(_wrap_File_id3v1_tag), -1);
   rb_define_method(SwigClassFile.klass, "apetag", VALUEFUNC(_wrap_File_apetag), -1);
   rb_define_method(SwigClassFile.klass, "strip", VALUEFUNC(_wrap_File_strip), -1);
-  rb_define_method(SwigClassFile.klass, "set_id3v2_frame_factory", VALUEFUNC(_wrap_File_set_id3v2_frame_factory), -1);
   rb_define_method(SwigClassFile.klass, "first_frame_offset", VALUEFUNC(_wrap_File_first_frame_offset), -1);
   rb_define_method(SwigClassFile.klass, "next_frame_offset", VALUEFUNC(_wrap_File_next_frame_offset), -1);
   rb_define_method(SwigClassFile.klass, "previous_frame_offset", VALUEFUNC(_wrap_File_previous_frame_offset), -1);

--- a/ext/taglib_ogg/taglib_ogg.i
+++ b/ext/taglib_ogg/taglib_ogg.i
@@ -4,8 +4,6 @@
 #include <taglib/oggfile.h>
 #include <taglib/flacpicture.h>
 #include <taglib/xiphcomment.h>
-// Help find FLAC::
-using namespace TagLib;
 %}
 
 %include "../taglib_base/includes.i"

--- a/ext/taglib_ogg/taglib_ogg_wrap.cxx
+++ b/ext/taglib_ogg/taglib_ogg_wrap.cxx
@@ -1859,12 +1859,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__Ogg__XiphComment swig_types[6]
 #define SWIGTYPE_p_TagLib__Tag swig_types[7]
 #define SWIGTYPE_p_char swig_types[8]
-#define SWIGTYPE_p_unsigned_char swig_types[9]
-#define SWIGTYPE_p_unsigned_int swig_types[10]
-#define SWIGTYPE_p_unsigned_long swig_types[11]
-#define SWIGTYPE_p_wchar_t swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[9]
+#define SWIGTYPE_p_unsigned_char swig_types[10]
+#define SWIGTYPE_p_unsigned_int swig_types[11]
+#define SWIGTYPE_p_unsigned_long swig_types[12]
+#define SWIGTYPE_p_wchar_t swig_types[13]
+static swig_type_info *swig_types[15];
+static swig_module_info swig_module = {swig_types, 14, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1938,8 +1939,6 @@ template <typename T> T SwigValueInit() {
 #include <taglib/oggfile.h>
 #include <taglib/flacpicture.h>
 #include <taglib/xiphcomment.h>
-// Help find FLAC::
-using namespace TagLib;
 
 
 #include <taglib/tstring.h>
@@ -1960,34 +1959,26 @@ using namespace TagLib;
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2076,6 +2067,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 VALUE taglib_flac_picturelist_to_ruby_array(const TagLib::List<TagLib::FLAC::Picture *> & list) {
@@ -3340,32 +3338,6 @@ fail:
 SWIGINTERN VALUE
 _wrap_XiphComment_render__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::Ogg::XiphComment *arg1 = (TagLib::Ogg::XiphComment *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  TagLib::ByteVector result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__Ogg__XiphComment, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Ogg::XiphComment const *","render", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Ogg::XiphComment * >(argp1);
-  result = ((TagLib::Ogg::XiphComment const *)arg1)->render();
-  {
-    vresult = taglib_bytevector_to_ruby_string(result);
-  }
-  return vresult;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_XiphComment_render__SWIG_1(int argc, VALUE *argv, VALUE self) {
-  TagLib::Ogg::XiphComment *arg1 = (TagLib::Ogg::XiphComment *) 0 ;
   bool arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -3397,6 +3369,32 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_XiphComment_render__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::Ogg::XiphComment *arg1 = (TagLib::Ogg::XiphComment *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  TagLib::ByteVector result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__Ogg__XiphComment, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Ogg::XiphComment const *","render", 1, self )); 
+  }
+  arg1 = reinterpret_cast< TagLib::Ogg::XiphComment * >(argp1);
+  result = ((TagLib::Ogg::XiphComment const *)arg1)->render();
+  {
+    vresult = taglib_bytevector_to_ruby_string(result);
+  }
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 SWIGINTERN VALUE _wrap_XiphComment_render(int nargs, VALUE *args, VALUE self) {
   int argc;
   VALUE argv[3];
@@ -3414,7 +3412,7 @@ SWIGINTERN VALUE _wrap_XiphComment_render(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_TagLib__Ogg__XiphComment, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_XiphComment_render__SWIG_0(nargs, args, self);
+      return _wrap_XiphComment_render__SWIG_1(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -3428,15 +3426,15 @@ SWIGINTERN VALUE _wrap_XiphComment_render(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_XiphComment_render__SWIG_1(nargs, args, self);
+        return _wrap_XiphComment_render__SWIG_0(nargs, args, self);
       }
     }
   }
   
 fail:
   Ruby_Format_OverloadedError( argc, 3, "XiphComment.render", 
-    "    TagLib::ByteVector XiphComment.render()\n"
-    "    TagLib::ByteVector XiphComment.render(bool addFramingBit)\n");
+    "    TagLib::ByteVector XiphComment.render(bool addFramingBit)\n"
+    "    TagLib::ByteVector XiphComment.render()\n");
   
   return Qnil;
 }
@@ -3657,6 +3655,7 @@ static swig_type_info _swigt__p_TagLib__Ogg__PageHeader = {"_p_TagLib__Ogg__Page
 static swig_type_info _swigt__p_TagLib__Ogg__XiphComment = {"_p_TagLib__Ogg__XiphComment", "TagLib::Ogg::XiphComment *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -3672,6 +3671,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__Ogg__XiphComment,
   &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -3687,6 +3687,7 @@ static swig_cast_info _swigc__p_TagLib__Ogg__PageHeader[] = {  {&_swigt__p_TagLi
 static swig_cast_info _swigc__p_TagLib__Ogg__XiphComment[] = {  {&_swigt__p_TagLib__Ogg__XiphComment, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},  {&_swigt__p_TagLib__Ogg__XiphComment, _p_TagLib__Ogg__XiphCommentTo_p_TagLib__Tag, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -3702,6 +3703,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__Ogg__XiphComment,
   _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,

--- a/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
+++ b/ext/taglib_vorbis/taglib_vorbis_wrap.cxx
@@ -1862,12 +1862,13 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 #define SWIGTYPE_p_TagLib__Vorbis__File swig_types[6]
 #define SWIGTYPE_p_TagLib__Vorbis__Properties swig_types[7]
 #define SWIGTYPE_p_char swig_types[8]
-#define SWIGTYPE_p_unsigned_char swig_types[9]
-#define SWIGTYPE_p_unsigned_int swig_types[10]
-#define SWIGTYPE_p_unsigned_long swig_types[11]
-#define SWIGTYPE_p_wchar_t swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+#define SWIGTYPE_p_long_long swig_types[9]
+#define SWIGTYPE_p_unsigned_char swig_types[10]
+#define SWIGTYPE_p_unsigned_int swig_types[11]
+#define SWIGTYPE_p_unsigned_long swig_types[12]
+#define SWIGTYPE_p_wchar_t swig_types[13]
+static swig_type_info *swig_types[15];
+static swig_module_info swig_module = {swig_types, 14, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1960,34 +1961,26 @@ template <typename T> T SwigValueInit() {
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2076,6 +2069,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 #include <limits.h>
@@ -2375,30 +2375,6 @@ free_TagLib_Vorbis_Properties(void *self) {
     SWIG_RubyRemoveTracking(arg1);
     delete arg1;
 }
-
-SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::Vorbis::Properties *arg1 = (TagLib::Vorbis::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__Vorbis__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::Vorbis::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::Vorbis::Properties * >(argp1);
-  result = (int)((TagLib::Vorbis::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
 
 SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
@@ -2874,14 +2850,15 @@ static void *_p_TagLib__Vorbis__FileTo_p_TagLib__Ogg__File(void *x, int *SWIGUNU
     return (void *)((TagLib::Ogg::File *)  ((TagLib::Vorbis::File *) x));
 }
 static swig_type_info _swigt__p_MapT_TagLib__String_TagLib__StringList_t = {"_p_MapT_TagLib__String_TagLib__StringList_t", "TagLib::Ogg::FieldListMap *|Map< TagLib::String,TagLib::StringList > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__AudioProperties = {"_p_TagLib__AudioProperties", "TagLib::Ogg::Vorbis::AudioProperties *|TagLib::AudioProperties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__AudioProperties = {"_p_TagLib__AudioProperties", "TagLib::AudioProperties *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__File = {"_p_TagLib__File", "TagLib::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ListT_TagLib__FLAC__Picture_t = {"_p_TagLib__ListT_TagLib__FLAC__Picture_t", "TagLib::FLAC::PictureList *|TagLib::List< TagLib::FLAC::Picture > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Ogg__File = {"_p_TagLib__Ogg__File", "TagLib::Ogg::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Ogg__XiphComment = {"_p_TagLib__Ogg__XiphComment", "TagLib::Ogg::XiphComment *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__Vorbis__File = {"_p_TagLib__Vorbis__File", "TagLib::Ogg::Vorbis::File *|TagLib::Vorbis::File *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_TagLib__Vorbis__Properties = {"_p_TagLib__Vorbis__Properties", "TagLib::Vorbis::Properties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__Vorbis__Properties = {"_p_TagLib__Vorbis__Properties", "TagLib::Ogg::Vorbis::Properties *|TagLib::Vorbis::Properties *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -2897,6 +2874,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__Vorbis__File,
   &_swigt__p_TagLib__Vorbis__Properties,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -2912,6 +2890,7 @@ static swig_cast_info _swigc__p_TagLib__Ogg__XiphComment[] = {  {&_swigt__p_TagL
 static swig_cast_info _swigc__p_TagLib__Vorbis__File[] = {  {&_swigt__p_TagLib__Vorbis__File, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__Vorbis__Properties[] = {  {&_swigt__p_TagLib__Vorbis__Properties, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -2927,6 +2906,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__Vorbis__File,
   _swigc__p_TagLib__Vorbis__Properties,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -3198,7 +3178,6 @@ SWIGEXPORT void Init_taglib_vorbis(void) {
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__Vorbis__Properties, (void *) &SwigClassProperties);
   rb_define_alloc_func(SwigClassProperties.klass, _wrap_Properties_allocate);
   rb_define_method(SwigClassProperties.klass, "initialize", VALUEFUNC(_wrap_new_Properties), -1);
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);

--- a/ext/taglib_wav/taglib_wav.i
+++ b/ext/taglib_wav/taglib_wav.i
@@ -4,7 +4,10 @@
 #include <taglib/wavfile.h>
 #include <taglib/wavproperties.h>
 #include <taglib/id3v2tag.h>
+#include <taglib/tpicturetype.h>
 using namespace TagLib::RIFF;
+using namespace TagLib;
+using StripTags = TagLib::File::StripTags;
 %}
 
 %include "../taglib_base/includes.i"
@@ -55,7 +58,11 @@ namespace TagLib {
   static void free_taglib_riff_wav_file(void *ptr) {
     TagLib::RIFF::WAV::File *file = (TagLib::RIFF::WAV::File *) ptr;
 
+#if TAGLIB_MAJOR_VERSION >= 2
+    TagLib::ID3v2::Tag *id3v2tag = file->ID3v2Tag();
+#else
     TagLib::ID3v2::Tag *id3v2tag = file->tag();
+#endif
     if (id3v2tag) {
       TagLib::ID3v2::FrameList frames = id3v2tag->frameList();
       for (TagLib::ID3v2::FrameList::ConstIterator it = frames.begin(); it != frames.end(); it++) {

--- a/ext/taglib_wav/taglib_wav.i
+++ b/ext/taglib_wav/taglib_wav.i
@@ -4,10 +4,6 @@
 #include <taglib/wavfile.h>
 #include <taglib/wavproperties.h>
 #include <taglib/id3v2tag.h>
-#include <taglib/tpicturetype.h>
-using namespace TagLib::RIFF;
-using namespace TagLib;
-using StripTags = TagLib::File::StripTags;
 %}
 
 %include "../taglib_base/includes.i"
@@ -18,6 +14,9 @@ using StripTags = TagLib::File::StripTags;
 %ignore TagLib::RIFF::WAV::Properties::Properties(const ByteVector&, unsigned int, ReadStyle);
 %ignore TagLib::RIFF::WAV::Properties::length;
 %ignore TagLib::RIFF::WAV::Properties::sampleWidth;
+
+%ignore TagLib::RIFF::File;
+%include <taglib/rifffile.h>
 
 %include <taglib/wavproperties.h>
 
@@ -31,6 +30,7 @@ namespace TagLib {
 
 // Ignore IOStream and all the constructors using it.
 %ignore IOStream;
+%ignore TagLib::RIFF::WAV::File::File(IOStream *, bool, Properties::ReadStyle, ID3v2::FrameFactory *f);
 %ignore TagLib::RIFF::WAV::File::File(IOStream *, bool, Properties::ReadStyle);
 %ignore TagLib::RIFF::WAV::File::File(IOStream *, bool);
 %ignore TagLib::RIFF::WAV::File::File(IOStream *);
@@ -58,11 +58,7 @@ namespace TagLib {
   static void free_taglib_riff_wav_file(void *ptr) {
     TagLib::RIFF::WAV::File *file = (TagLib::RIFF::WAV::File *) ptr;
 
-#if TAGLIB_MAJOR_VERSION >= 2
     TagLib::ID3v2::Tag *id3v2tag = file->ID3v2Tag();
-#else
-    TagLib::ID3v2::Tag *id3v2tag = file->tag();
-#endif
     if (id3v2tag) {
       TagLib::ID3v2::FrameList frames = id3v2tag->frameList();
       for (TagLib::ID3v2::FrameList::ConstIterator it = frames.begin(); it != frames.end(); it++) {

--- a/ext/taglib_wav/taglib_wav_wrap.cxx
+++ b/ext/taglib_wav/taglib_wav_wrap.cxx
@@ -1854,16 +1854,22 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 /* -------- TYPES TABLE (BEGIN) -------- */
 
 #define SWIGTYPE_p_TagLib__AudioProperties swig_types[0]
-#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[1]
-#define SWIGTYPE_p_TagLib__RIFF__WAV__File swig_types[2]
-#define SWIGTYPE_p_TagLib__RIFF__WAV__Properties swig_types[3]
-#define SWIGTYPE_p_char swig_types[4]
-#define SWIGTYPE_p_unsigned_char swig_types[5]
-#define SWIGTYPE_p_unsigned_int swig_types[6]
-#define SWIGTYPE_p_unsigned_long swig_types[7]
-#define SWIGTYPE_p_wchar_t swig_types[8]
-static swig_type_info *swig_types[10];
-static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
+#define SWIGTYPE_p_TagLib__File swig_types[1]
+#define SWIGTYPE_p_TagLib__ID3v2__FrameFactory swig_types[2]
+#define SWIGTYPE_p_TagLib__ID3v2__Tag swig_types[3]
+#define SWIGTYPE_p_TagLib__ID3v2__Version swig_types[4]
+#define SWIGTYPE_p_TagLib__RIFF__File swig_types[5]
+#define SWIGTYPE_p_TagLib__RIFF__WAV__File swig_types[6]
+#define SWIGTYPE_p_TagLib__RIFF__WAV__Properties swig_types[7]
+#define SWIGTYPE_p_TagLib__Tag swig_types[8]
+#define SWIGTYPE_p_char swig_types[9]
+#define SWIGTYPE_p_long_long swig_types[10]
+#define SWIGTYPE_p_unsigned_char swig_types[11]
+#define SWIGTYPE_p_unsigned_int swig_types[12]
+#define SWIGTYPE_p_unsigned_long swig_types[13]
+#define SWIGTYPE_p_wchar_t swig_types[14]
+static swig_type_info *swig_types[16];
+static swig_module_info swig_module = {swig_types, 15, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1937,7 +1943,6 @@ template <typename T> T SwigValueInit() {
 #include <taglib/wavfile.h>
 #include <taglib/wavproperties.h>
 #include <taglib/id3v2tag.h>
-using namespace TagLib::RIFF;
 
 
 #include <taglib/tstring.h>
@@ -1958,34 +1963,26 @@ using namespace TagLib::RIFF;
 #endif
 
 VALUE taglib_bytevector_to_ruby_string(const TagLib::ByteVector &byteVector) {
-  if (byteVector.isNull()) {
-    return Qnil;
-  } else {
-    return rb_str_new(byteVector.data(), byteVector.size());
-  }
+  return rb_str_new(byteVector.data(), byteVector.size());
 }
 
 TagLib::ByteVector ruby_string_to_taglib_bytevector(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::ByteVector::null;
+    return TagLib::ByteVector();
   } else {
     return TagLib::ByteVector(RSTRING_PTR(StringValue(s)), RSTRING_LEN(s));
   }
 }
 
 VALUE taglib_string_to_ruby_string(const TagLib::String & string) {
-  if (string.isNull()) {
-    return Qnil;
-  } else {
-    VALUE result = rb_str_new2(string.toCString(true));
-    ASSOCIATE_UTF8_ENCODING(result);
-    return result;
-  }
+  VALUE result = rb_str_new2(string.toCString(true));
+  ASSOCIATE_UTF8_ENCODING(result);
+  return result;
 }
 
 TagLib::String ruby_string_to_taglib_string(VALUE s) {
   if (NIL_P(s)) {
-    return TagLib::String::null;
+    return TagLib::String();
   } else {
     return TagLib::String(RSTRING_PTR(CONVERT_TO_UTF8(StringValue(s))), TagLib::String::UTF8);
   }
@@ -2074,6 +2071,13 @@ TagLib::FileName ruby_string_to_taglib_filename(VALUE s) {
 #endif
 }
 
+VALUE taglib_offset_t_to_ruby_int(TagLib::offset_t off) {
+#ifdef _WIN32
+  return LL2NUM(off);
+#else
+  return OFFT2NUM(off);
+#endif
+}
 
 
 #include <limits.h>
@@ -2246,7 +2250,7 @@ SWIGINTERN void TagLib_RIFF_WAV_File_close(TagLib::RIFF::WAV::File *self){
   static void free_taglib_riff_wav_file(void *ptr) {
     TagLib::RIFF::WAV::File *file = (TagLib::RIFF::WAV::File *) ptr;
 
-    TagLib::ID3v2::Tag *id3v2tag = file->tag();
+    TagLib::ID3v2::Tag *id3v2tag = file->ID3v2Tag();
     if (id3v2tag) {
       TagLib::ID3v2::FrameList frames = id3v2tag->frameList();
       for (TagLib::ID3v2::FrameList::ConstIterator it = frames.begin(); it != frames.end(); it++) {
@@ -2326,30 +2330,6 @@ free_TagLib_RIFF_WAV_Properties(void *self) {
     SWIG_RubyRemoveTracking(arg1);
     delete arg1;
 }
-
-SWIGINTERN VALUE
-_wrap_Properties_length_in_seconds(int argc, VALUE *argv, VALUE self) {
-  TagLib::RIFF::WAV::Properties *arg1 = (TagLib::RIFF::WAV::Properties *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_TagLib__RIFF__WAV__Properties, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::RIFF::WAV::Properties const *","lengthInSeconds", 1, self )); 
-  }
-  arg1 = reinterpret_cast< TagLib::RIFF::WAV::Properties * >(argp1);
-  result = (int)((TagLib::RIFF::WAV::Properties const *)arg1)->lengthInSeconds();
-  vresult = SWIG_From_int(static_cast< int >(result));
-  return vresult;
-fail:
-  return Qnil;
-}
-
 
 SWIGINTERN VALUE
 _wrap_Properties_length_in_milliseconds(int argc, VALUE *argv, VALUE self) {
@@ -2526,6 +2506,53 @@ _wrap_new_File__SWIG_0(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   TagLib::RIFF::WAV::Properties::ReadStyle arg3 ;
+  TagLib::ID3v2::FrameFactory *arg4 = (TagLib::ID3v2::FrameFactory *) 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  TagLib::RIFF::WAV::File *result = 0 ;
+  
+  if ((argc < 4) || (argc > 4)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  }
+  {
+    arg1 = ruby_string_to_taglib_filename(argv[0]);
+    if ((const char *)(TagLib::FileName)(arg1) == NULL) {
+      SWIG_exception_fail(SWIG_MemoryError, "Failed to allocate memory for file name.");
+    }
+  }
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","File", 2, argv[1] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::RIFF::WAV::Properties::ReadStyle","File", 3, argv[2] ));
+  } 
+  arg3 = static_cast< TagLib::RIFF::WAV::Properties::ReadStyle >(val3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4,SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::ID3v2::FrameFactory *","File", 4, argv[3] )); 
+  }
+  arg4 = reinterpret_cast< TagLib::ID3v2::FrameFactory * >(argp4);
+  result = (TagLib::RIFF::WAV::File *)new TagLib::RIFF::WAV::File(arg1,arg2,arg3,arg4);
+  DATA_PTR(self) = result;
+  SWIG_RubyAddTracking(result, self);
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  TagLib::FileName arg1 ;
+  bool arg2 ;
+  TagLib::RIFF::WAV::Properties::ReadStyle arg3 ;
   bool val2 ;
   int ecode2 = 0 ;
   int val3 ;
@@ -2561,7 +2588,7 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_1(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   bool arg2 ;
   bool val2 ;
@@ -2607,7 +2634,7 @@ _wrap_File_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_File__SWIG_2(int argc, VALUE *argv, VALUE self) {
+_wrap_new_File__SWIG_3(int argc, VALUE *argv, VALUE self) {
   TagLib::FileName arg1 ;
   TagLib::RIFF::WAV::File *result = 0 ;
   
@@ -2631,11 +2658,11 @@ fail:
 
 SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
   int argc;
-  VALUE argv[3];
+  VALUE argv[4];
   int ii;
   
   argc = nargs;
-  if (argc > 3) SWIG_fail;
+  if (argc > 4) SWIG_fail;
   for (ii = 0; (ii < argc); ++ii) {
     argv[ii] = args[ii];
   }
@@ -2644,7 +2671,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_new_File__SWIG_2(nargs, args, self);
+      return _wrap_new_File__SWIG_3(nargs, args, self);
     }
   }
   if (argc == 2) {
@@ -2657,7 +2684,7 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        return _wrap_new_File__SWIG_1(nargs, args, self);
+        return _wrap_new_File__SWIG_2(nargs, args, self);
       }
     }
   }
@@ -2676,14 +2703,40 @@ SWIGINTERN VALUE _wrap_new_File(int nargs, VALUE *args, VALUE self) {
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          return _wrap_new_File__SWIG_0(nargs, args, self);
+          return _wrap_new_File__SWIG_1(nargs, args, self);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__ID3v2__FrameFactory, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_new_File__SWIG_0(nargs, args, self);
+          }
         }
       }
     }
   }
   
 fail:
-  Ruby_Format_OverloadedError( argc, 3, "File.new", 
+  Ruby_Format_OverloadedError( argc, 4, "File.new", 
+    "    File.new(TagLib::FileName file, bool readProperties, TagLib::RIFF::WAV::Properties::ReadStyle propertiesStyle, TagLib::ID3v2::FrameFactory *frameFactory)\n"
     "    File.new(TagLib::FileName file, bool readProperties, TagLib::RIFF::WAV::Properties::ReadStyle propertiesStyle)\n"
     "    File.new(TagLib::FileName file, bool readProperties)\n"
     "    File.new(TagLib::FileName file)\n");
@@ -2697,7 +2750,7 @@ _wrap_File_tag(int argc, VALUE *argv, VALUE self) {
   TagLib::RIFF::WAV::File *arg1 = (TagLib::RIFF::WAV::File *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  TagLib::ID3v2::Tag *result = 0 ;
+  TagLib::Tag *result = 0 ;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -2708,8 +2761,8 @@ _wrap_File_tag(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "TagLib::RIFF::WAV::File const *","tag", 1, self )); 
   }
   arg1 = reinterpret_cast< TagLib::RIFF::WAV::File * >(argp1);
-  result = (TagLib::ID3v2::Tag *)((TagLib::RIFF::WAV::File const *)arg1)->tag();
-  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__ID3v2__Tag, 0 |  0 );
+  result = (TagLib::Tag *)((TagLib::RIFF::WAV::File const *)arg1)->tag();
+  vresult = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_TagLib__Tag, 0 |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -2887,16 +2940,16 @@ SWIGINTERN VALUE
 _wrap_File_save__SWIG_1(int argc, VALUE *argv, VALUE self) {
   TagLib::RIFF::WAV::File *arg1 = (TagLib::RIFF::WAV::File *) 0 ;
   TagLib::RIFF::WAV::File::TagTypes arg2 ;
-  bool arg3 ;
-  int arg4 ;
+  TagLib::File::StripTags arg3 ;
+  TagLib::ID3v2::Version arg4 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  bool val3 ;
+  int val3 ;
   int ecode3 = 0 ;
-  int val4 ;
-  int ecode4 = 0 ;
+  void *argp4 ;
+  int res4 = 0 ;
   bool result;
   VALUE vresult = Qnil;
   
@@ -2913,16 +2966,22 @@ _wrap_File_save__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::RIFF::WAV::File::TagTypes","save", 2, argv[0] ));
   } 
   arg2 = static_cast< TagLib::RIFF::WAV::File::TagTypes >(val2);
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","save", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::StripTags","save", 3, argv[1] ));
   } 
-  arg3 = static_cast< bool >(val3);
-  ecode4 = SWIG_AsVal_int(argv[2], &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "int","save", 4, argv[2] ));
-  } 
-  arg4 = static_cast< int >(val4);
+  arg3 = static_cast< TagLib::File::StripTags >(val3);
+  {
+    res4 = SWIG_ConvertPtr(argv[2], &argp4, SWIGTYPE_p_TagLib__ID3v2__Version,  0 );
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), Ruby_Format_TypeError( "", "TagLib::ID3v2::Version","save", 4, argv[2] )); 
+    }  
+    if (!argp4) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "TagLib::ID3v2::Version","save", 4, argv[2]));
+    } else {
+      arg4 = *(reinterpret_cast< TagLib::ID3v2::Version * >(argp4));
+    }
+  }
   result = (bool)(arg1)->save(arg2,arg3,arg4);
   vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
@@ -2935,12 +2994,12 @@ SWIGINTERN VALUE
 _wrap_File_save__SWIG_2(int argc, VALUE *argv, VALUE self) {
   TagLib::RIFF::WAV::File *arg1 = (TagLib::RIFF::WAV::File *) 0 ;
   TagLib::RIFF::WAV::File::TagTypes arg2 ;
-  bool arg3 ;
+  TagLib::File::StripTags arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  bool val3 ;
+  int val3 ;
   int ecode3 = 0 ;
   bool result;
   VALUE vresult = Qnil;
@@ -2958,11 +3017,11 @@ _wrap_File_save__SWIG_2(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "TagLib::RIFF::WAV::File::TagTypes","save", 2, argv[0] ));
   } 
   arg2 = static_cast< TagLib::RIFF::WAV::File::TagTypes >(val2);
-  ecode3 = SWIG_AsVal_bool(argv[1], &val3);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "bool","save", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "TagLib::File::StripTags","save", 3, argv[1] ));
   } 
-  arg3 = static_cast< bool >(val3);
+  arg3 = static_cast< TagLib::File::StripTags >(val3);
   result = (bool)(arg1)->save(arg2,arg3);
   vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
@@ -3050,7 +3109,7 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
+          int res = SWIG_AsVal_int(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -3071,14 +3130,13 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
+          int res = SWIG_AsVal_int(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
-          {
-            int res = SWIG_AsVal_int(argv[3], NULL);
-            _v = SWIG_CheckState(res);
-          }
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_TagLib__ID3v2__Version, SWIG_POINTER_NO_NULL);
+          _v = SWIG_CheckState(res);
           if (_v) {
             return _wrap_File_save__SWIG_1(nargs, args, self);
           }
@@ -3090,8 +3148,8 @@ SWIGINTERN VALUE _wrap_File_save(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 5, "File.save", 
     "    bool File.save()\n"
-    "    bool File.save(TagLib::RIFF::WAV::File::TagTypes tags, bool stripOthers, int id3v2Version)\n"
-    "    bool File.save(TagLib::RIFF::WAV::File::TagTypes tags, bool stripOthers)\n"
+    "    bool File.save(TagLib::RIFF::WAV::File::TagTypes tags, TagLib::File::StripTags strip, TagLib::ID3v2::Version version)\n"
+    "    bool File.save(TagLib::RIFF::WAV::File::TagTypes tags, TagLib::File::StripTags strip)\n"
     "    bool File.save(TagLib::RIFF::WAV::File::TagTypes tags)\n");
   
   return Qnil;
@@ -3173,11 +3231,26 @@ fail:
 static void *_p_TagLib__RIFF__WAV__PropertiesTo_p_TagLib__AudioProperties(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((TagLib::AudioProperties *)  ((TagLib::RIFF::WAV::Properties *) x));
 }
+static void *_p_TagLib__RIFF__FileTo_p_TagLib__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::File *)  ((TagLib::RIFF::File *) x));
+}
+static void *_p_TagLib__RIFF__WAV__FileTo_p_TagLib__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::File *) (TagLib::RIFF::File *) ((TagLib::RIFF::WAV::File *) x));
+}
+static void *_p_TagLib__RIFF__WAV__FileTo_p_TagLib__RIFF__File(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((TagLib::RIFF::File *)  ((TagLib::RIFF::WAV::File *) x));
+}
 static swig_type_info _swigt__p_TagLib__AudioProperties = {"_p_TagLib__AudioProperties", "TagLib::AudioProperties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__File = {"_p_TagLib__File", "TagLib::File *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__ID3v2__FrameFactory = {"_p_TagLib__ID3v2__FrameFactory", "TagLib::ID3v2::FrameFactory *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__ID3v2__Tag = {"_p_TagLib__ID3v2__Tag", "TagLib::ID3v2::Tag *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__ID3v2__Version = {"_p_TagLib__ID3v2__Version", "TagLib::ID3v2::Version *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__RIFF__File = {"_p_TagLib__RIFF__File", "TagLib::RIFF::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__RIFF__WAV__File = {"_p_TagLib__RIFF__WAV__File", "TagLib::RIFF::WAV::File *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TagLib__RIFF__WAV__Properties = {"_p_TagLib__RIFF__WAV__Properties", "TagLib::RIFF::WAV::Properties *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_TagLib__Tag = {"_p_TagLib__Tag", "TagLib::Tag *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long_long = {"_p_long_long", "TagLib::offset_t *|long long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "TagLib::uchar *|unsigned char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_int = {"_p_unsigned_int", "TagLib::uint *|unsigned int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_long = {"_p_unsigned_long", "TagLib::ulong *|unsigned long *", 0, 0, (void*)0, 0};
@@ -3185,10 +3258,16 @@ static swig_type_info _swigt__p_wchar_t = {"_p_wchar_t", "TagLib::wchar *|wchar_
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_TagLib__AudioProperties,
+  &_swigt__p_TagLib__File,
+  &_swigt__p_TagLib__ID3v2__FrameFactory,
   &_swigt__p_TagLib__ID3v2__Tag,
+  &_swigt__p_TagLib__ID3v2__Version,
+  &_swigt__p_TagLib__RIFF__File,
   &_swigt__p_TagLib__RIFF__WAV__File,
   &_swigt__p_TagLib__RIFF__WAV__Properties,
+  &_swigt__p_TagLib__Tag,
   &_swigt__p_char,
+  &_swigt__p_long_long,
   &_swigt__p_unsigned_char,
   &_swigt__p_unsigned_int,
   &_swigt__p_unsigned_long,
@@ -3196,10 +3275,16 @@ static swig_type_info *swig_type_initial[] = {
 };
 
 static swig_cast_info _swigc__p_TagLib__AudioProperties[] = {  {&_swigt__p_TagLib__AudioProperties, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__WAV__Properties, _p_TagLib__RIFF__WAV__PropertiesTo_p_TagLib__AudioProperties, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__File[] = {  {&_swigt__p_TagLib__File, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__File, _p_TagLib__RIFF__FileTo_p_TagLib__File, 0, 0},  {&_swigt__p_TagLib__RIFF__WAV__File, _p_TagLib__RIFF__WAV__FileTo_p_TagLib__File, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__ID3v2__FrameFactory[] = {  {&_swigt__p_TagLib__ID3v2__FrameFactory, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__ID3v2__Tag[] = {  {&_swigt__p_TagLib__ID3v2__Tag, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__ID3v2__Version[] = {  {&_swigt__p_TagLib__ID3v2__Version, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__RIFF__File[] = {  {&_swigt__p_TagLib__RIFF__File, 0, 0, 0},  {&_swigt__p_TagLib__RIFF__WAV__File, _p_TagLib__RIFF__WAV__FileTo_p_TagLib__RIFF__File, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__RIFF__WAV__File[] = {  {&_swigt__p_TagLib__RIFF__WAV__File, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TagLib__RIFF__WAV__Properties[] = {  {&_swigt__p_TagLib__RIFF__WAV__Properties, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_TagLib__Tag[] = {  {&_swigt__p_TagLib__Tag, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_long_long[] = {  {&_swigt__p_long_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_char[] = {  {&_swigt__p_unsigned_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_int[] = {  {&_swigt__p_unsigned_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_unsigned_long[] = {  {&_swigt__p_unsigned_long, 0, 0, 0},{0, 0, 0, 0}};
@@ -3207,10 +3292,16 @@ static swig_cast_info _swigc__p_wchar_t[] = {  {&_swigt__p_wchar_t, 0, 0, 0},{0,
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_TagLib__AudioProperties,
+  _swigc__p_TagLib__File,
+  _swigc__p_TagLib__ID3v2__FrameFactory,
   _swigc__p_TagLib__ID3v2__Tag,
+  _swigc__p_TagLib__ID3v2__Version,
+  _swigc__p_TagLib__RIFF__File,
   _swigc__p_TagLib__RIFF__WAV__File,
   _swigc__p_TagLib__RIFF__WAV__Properties,
+  _swigc__p_TagLib__Tag,
   _swigc__p_char,
+  _swigc__p_long_long,
   _swigc__p_unsigned_char,
   _swigc__p_unsigned_int,
   _swigc__p_unsigned_long,
@@ -3480,7 +3571,6 @@ SWIGEXPORT void Init_taglib_wav(void) {
   SWIG_TypeClientData(SWIGTYPE_p_TagLib__RIFF__WAV__Properties, (void *) &SwigClassProperties);
   rb_define_alloc_func(SwigClassProperties.klass, _wrap_Properties_allocate);
   rb_define_method(SwigClassProperties.klass, "initialize", VALUEFUNC(_wrap_new_Properties), -1);
-  rb_define_method(SwigClassProperties.klass, "length_in_seconds", VALUEFUNC(_wrap_Properties_length_in_seconds), -1);
   rb_define_method(SwigClassProperties.klass, "length_in_milliseconds", VALUEFUNC(_wrap_Properties_length_in_milliseconds), -1);
   rb_define_method(SwigClassProperties.klass, "bitrate", VALUEFUNC(_wrap_Properties_bitrate), -1);
   rb_define_method(SwigClassProperties.klass, "sample_rate", VALUEFUNC(_wrap_Properties_sample_rate), -1);

--- a/tasks/build.rb
+++ b/tasks/build.rb
@@ -7,7 +7,7 @@ class Build
     end
 
     def version
-      ENV['TAGLIB_VERSION'] || '1.11.1'
+      ENV['TAGLIB_VERSION'] || '2.0.1'
     end
 
     def dir

--- a/tasks/build.rb
+++ b/tasks/build.rb
@@ -22,10 +22,6 @@ class Build
       "#{tmp}/#{dir}"
     end
 
-    def tarball
-      "#{source}.tar.gz"
-    end
-
     def tmp_arch
       "#{tmp}/#{plat}"
     end

--- a/tasks/ext.rake
+++ b/tasks/ext.rake
@@ -93,17 +93,8 @@ directory Build.install_dir
 directory Build.build_dir
 directory Build.tmp
 
-file Build.source => [Build.tarball] do
-  chdir Build.tmp do
-    sh "tar xzf #{Build.tarball}"
-  end
-end
-
-file Build.tarball => [Build.tmp] do |t|
-  require 'open-uri'
-  puts "Downloading #{taglib_url}"
-
-  File.open(t.name, 'wb') do |f|
-    IO.copy_stream(URI.open(taglib_url), f)
-  end
+file Build.source do
+  sh "git clone --depth=1 --branch=v#{Build.version} https://github.com/taglib/taglib.git #{Build.source}"
+  sh "git -C #{Build.source} submodule init"
+  sh "git -C #{Build.source} submodule update --depth=1"
 end

--- a/tasks/ext.rake
+++ b/tasks/ext.rake
@@ -13,6 +13,7 @@ taglib_url = "https://github.com/taglib/taglib/archive/v#{Build.version}.tar.gz"
 taglib_options = ['-DCMAKE_BUILD_TYPE=Release',
                   '-DBUILD_EXAMPLES=OFF',
                   '-DBUILD_TESTS=OFF',
+                  '-DBUILD_TESTING=OFF', # used since 1.13 instead of BUILD_TESTS
                   '-DBUILD_BINDINGS=OFF', # 1.11 builds bindings by default
                   '-DBUILD_SHARED_LIBS=ON', # 1.11 builds static by default
                   '-DWITH_MP4=ON', # WITH_MP4, WITH_ASF only needed with taglib 1.7, will be default in 1.8

--- a/test/id3v2_write_test.rb
+++ b/test/id3v2_write_test.rb
@@ -54,7 +54,7 @@ class TestID3v2Write < Test::Unit::TestCase
     end
 
     should 'be able to save ID3v2.3' do
-      success = @file.save(TagLib::MPEG::File::ID3v2, true, 3)
+      success = @file.save(TagLib::MPEG::File::ID3v2, TagLib::File::StripOthers, TagLib::ID3v2::V3)
       assert_equal true, success
       @file.close
       @file = nil

--- a/test/wav_examples_test.rb
+++ b/test/wav_examples_test.rb
@@ -19,7 +19,7 @@ class WAVExamples < Test::Unit::TestCase
 
       # Saving ID3v2 cover-art to disk
       TagLib::RIFF::WAV::File.open("#{DATA_FILE_PREFIX}sample.wav") do |file|
-        id3v2_tag = file.tag
+        id3v2_tag = file.id3v2_tag
         cover = id3v2_tag.frame_list('APIC').first
         ext = cover.mime_type.rpartition('/')[2]
         File.open("#{DATA_FILE_PREFIX}cover-art.#{ext}", 'wb') { |f| f.write cover.picture }

--- a/test/wav_file_test.rb
+++ b/test/wav_file_test.rb
@@ -40,7 +40,7 @@ class WAVFileTest < Test::Unit::TestCase
 
     context 'ID3V2 tag' do
       setup do
-        @tag = @file.tag
+        @tag = @file.id3v2_tag
       end
 
       should 'exist' do

--- a/test/wav_file_write_test.rb
+++ b/test/wav_file_write_test.rb
@@ -33,18 +33,18 @@ class WAVFileWriteTest < Test::Unit::TestCase
     end
 
     should 'have one picture frame' do
-      assert_equal 2, @file.tag.frame_list('APIC').size
+      assert_equal 2, @file.id3v2_tag.frame_list('APIC').size
     end
 
     should 'be able to remove all picture frames' do
-      @file.tag.remove_frames('APIC')
+      @file.id3v2_tag.remove_frames('APIC')
       success = @file.save
       assert success
       @file.close
       @file = nil
 
       reloaded do |file|
-        assert_equal 0, file.tag.frame_list('APIC').size
+        assert_equal 0, file.id3v2_tag.frame_list('APIC').size
       end
     end
 
@@ -58,18 +58,18 @@ class WAVFileWriteTest < Test::Unit::TestCase
       apic.picture = picture_data
       apic.type = TagLib::ID3v2::AttachedPictureFrame::BackCover
 
-      @file.tag.add_frame(apic)
+      @file.id3v2_tag.add_frame(apic)
       success = @file.save
       assert success
       @file.close
       @file = nil
 
       reloaded do |file|
-        assert_equal 3, file.tag.frame_list('APIC').size
+        assert_equal 3, file.id3v2_tag.frame_list('APIC').size
       end
 
       reloaded do |file|
-        written_apic = file.tag.frame_list('APIC')[2]
+        written_apic = file.id3v2_tag.frame_list('APIC')[2]
         assert_equal 'image/jpeg', written_apic.mime_type
         assert_equal 'desc', written_apic.description
         assert_equal picture_data, written_apic.picture


### PR DESCRIPTION
This pulls together various commits into something reasonably clean that:

- uses TagLib 2.0.1
- passes our test suite