### PR TITLE
Update README.md and version.rb for taglib-ruby 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ installed with header files (and a C++ compiler of course):
 * Brew: `brew install taglib`
 * MacPorts: `sudo port install taglib`
 
-Then do:
+Then install the latest taglib-ruby 1.x by running:
 
-    gem install taglib-ruby
+    gem install taglib-ruby --version '< 2'
+
+If you are using TagLib 2.0.1 or higher, you need to install taglib-ruby 2.x instead:
+
+    gem install taglib-ruby --version '>= 2'
 
 ### MacOS
 

--- a/lib/taglib/version.rb
+++ b/lib/taglib/version.rb
@@ -2,9 +2,9 @@
 
 module TagLib
   module Version
-    MAJOR = 1
-    MINOR = 1
-    PATCH = 3
+    MAJOR = 2
+    MINOR = 0
+    PATCH = 0
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')


### PR DESCRIPTION
After we merge this I can tag a release and push it to rubygems.